### PR TITLE
Rename CSS folder to "Utilities"

### DIFF
--- a/themes/wporg-5ftf/Gruntfile.js
+++ b/themes/wporg-5ftf/Gruntfile.js
@@ -4,7 +4,7 @@ module.exports = function( grunt ) {
 
 	const getSassFiles = () => {
 		const files = {};
-		const paths = [ 'settings', 'tools', 'generic', 'base', 'objects', 'components', 'trumps' ];
+		const paths = [ 'settings', 'tools', 'generic', 'base', 'objects', 'components', 'utilities' ];
 
 		paths.forEach( function( component ) {
 			var paths = [

--- a/themes/wporg-5ftf/css/README.md
+++ b/themes/wporg-5ftf/css/README.md
@@ -1,0 +1,40 @@
+# CSS Structure
+
+This loosely follows [ITCSS.](https://www.xfive.co/blog/itcss-scalable-maintainable-css-architecture/)
+
+## 01 Settings
+
+Typography, colors, any spacing variables, etc should be set here.
+
+## 02 Tools
+
+This contains any mixins. We inherit the following libraries:
+
+- breakpoint
+- kube
+- modular-scale
+
+## 03 Generic
+
+Any generic styles. Used for normalize & reset styles. We inherit:
+
+- kube
+- normalize
+
+## 04 Base (aka Elements)
+
+Styles for plain html elements. We inherit the base theme's styling here.
+
+## 05 Objects
+
+These are pieces of UI. These should be self-contained (or nested so that they are self-contained). Blocks should
+be defined here.
+
+## 06 Components
+
+This section puts together the base and objects to create pages. Page-specific styles are defined here.
+
+## 07 Utilities
+
+The `is-*`/`has-*` classes, these custom classes override previous styles. For example, `has-background` would be
+defined here.

--- a/themes/wporg-5ftf/css/README.md
+++ b/themes/wporg-5ftf/css/README.md
@@ -37,4 +37,8 @@ This section puts together the base and objects to create pages. Page-specific s
 ## 07 Utilities
 
 The `is-*`/`has-*` classes, these custom classes override previous styles. For example, `has-background` would be
-defined here.
+defined here. This is where block styles should live.
+
+# Editor Styles
+
+Editor styles will use a custom import of a subset of the above folders, TBD?


### PR DESCRIPTION
Looking at [ITCSS,](https://www.xfive.co/blog/itcss-scalable-maintainable-css-architecture/) it appears this should be `utilities`. Since that's a name that has no negative connotations, let's use that instead.

Making this a PR in case there are unexpected edge cases here. I don't see anything in `pub/wporg/css/trumps/`, so I think we're clear to remove this in the child theme. 

I've also added an "outline" readme describing each CSS folder (since this is overall not a pattern I'm familiar with), you can see that [here.](https://github.com/WordPress/five-for-the-future/tree/remove/trumps/themes/wporg-5ftf/css)