### PR TITLE
New Pledge: Validate submitted form values and generate a draft pledge post

### DIFF
--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -202,7 +202,7 @@ function get_form_submission() {
 function has_existing_pledge( $key, $key_type, int $current_pledge_id = 0 ) {
 	$args = array(
 		'post_type'   => Pledge\CPT_ID,
-		'post_status' => array( 'pending', 'publish' ),
+		'post_status' => array( 'draft', 'pending', 'publish' ),
 	);
 
 	switch ( $key_type ) {

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -87,7 +87,6 @@ function process_form_new() {
 		return $contributors;
 	}
 
-	/*
 	$name = sanitize_meta(
 		PledgeMeta\META_PREFIX . 'org-name',
 		$submission['org-name'],
@@ -100,9 +99,6 @@ function process_form_new() {
 	if ( is_wp_error( $created ) ) {
 		return $created;
 	}
-
-	PledgeMeta\save_pledge_meta( $created, $submission );
-	*/
 
 	return 'success';
 }

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -16,7 +16,7 @@ const META_PREFIX = FiveForTheFuture\PREFIX . '_';
 
 add_action( 'init',                  __NAMESPACE__ . '\register_pledge_meta' );
 add_action( 'admin_init',            __NAMESPACE__ . '\add_meta_boxes' );
-add_action( 'save_post',             __NAMESPACE__ . '\save_pledge',           10, 2 );
+add_action( 'save_post',             __NAMESPACE__ . '\save_pledge', 10, 2 );
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 
 // Both hooks must be used because `updated` doesn't fire if the post meta didn't previously exist.
@@ -200,8 +200,7 @@ function save_pledge( $pledge_id, $pledge ) {
 		return;
 	}
 
-	$definitions    = wp_list_pluck( get_pledge_meta_config( 'user_input' ), 'php_filter' );
-	$submitted_meta = filter_input_array( INPUT_POST, $definitions );
+	$submitted_meta = PledgeForm\get_form_submission();
 
 	if ( is_wp_error( has_required_pledge_meta( $submitted_meta ) ) ) {
 		return;

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -252,6 +252,14 @@ function update_generated_meta( $meta_id, $object_id, $meta_key, $_meta_value ) 
 	}
 
 	switch ( $meta_key ) {
+		case META_PREFIX . 'org-name':
+			if ( 'updated_postmeta' === current_action() ) {
+				wp_update_post( array(
+					'post_title' => $_meta_value,
+				) );
+			}
+			break;
+
 		case META_PREFIX . 'org-url':
 			$domain = get_normalized_domain_from_url( $_meta_value );
 			update_post_meta( $object_id, META_PREFIX . 'org-domain', $domain );

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -7,6 +7,7 @@ namespace WordPressDotOrg\FiveForTheFuture\PledgeMeta;
 
 use WordPressDotOrg\FiveForTheFuture;
 use WordPressDotOrg\FiveForTheFuture\Pledge;
+use WordPressDotOrg\FiveForTheFuture\PledgeForm;
 use WP_Post, WP_Error;
 
 defined( 'WPINC' ) || die();
@@ -292,26 +293,6 @@ function has_required_pledge_meta( array $submission ) {
 }
 
 /**
- * Get the input filters for submitted content.
- *
- * @return array
- */
-function get_input_filters() {
-	return array_merge(
-		// Inputs that correspond to meta values.
-		wp_list_pluck( get_pledge_meta_config( 'user_input' ), 'php_filter' ),
-		// Inputs with no corresponding meta value.
-		array(
-			'contributor-wporg-usernames' => [
-				'filter' => FILTER_SANITIZE_STRING,
-				'flags'  => FILTER_REQUIRE_ARRAY,
-			],
-			'pledge-agreement'            => FILTER_VALIDATE_BOOLEAN,
-		)
-	);
-}
-
-/**
  * Get the metadata for a given pledge, or a default set if no pledge is provided.
  *
  * @param int    $pledge_id
@@ -326,13 +307,13 @@ function get_pledge_meta( $pledge_id = 0, $context = '' ) {
 	$meta = array();
 
 	// Get POST'd submission, if it exists.
-	$submission = filter_input_array( INPUT_POST, get_input_filters() );
+	$submission = PledgeForm\get_form_submission();
 
 	foreach ( $keys as $key => $config ) {
 		if ( isset( $submission[ $key ] ) ) {
 			$meta[ $key ] = $submission[ $key ];
-		} else if ( $pledge instanceof WP_Post ) {
-			$meta_key = META_PREFIX . $key;
+		} elseif ( $pledge instanceof WP_Post ) {
+			$meta_key     = META_PREFIX . $key;
 			$meta[ $key ] = get_post_meta( $pledge->ID, $meta_key, true );
 		} else {
 			$meta[ $key ] = $config['default'] ?: '';

--- a/plugins/wporg-5ftf/views/inputs-pledge-contributors.php
+++ b/plugins/wporg-5ftf/views/inputs-pledge-contributors.php
@@ -16,7 +16,7 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 		type="text"
 		id="5ftf-pledge-contributors"
 		name="pledge-contributors"
-		value=""
+		value="<?php echo esc_attr( $data['pledge-contributors'] ); ?>"
 		required
 		aria-describedby="5ftf-pledge-contributors-help"
 	/>

--- a/plugins/wporg-5ftf/views/inputs-pledge-new-misc.php
+++ b/plugins/wporg-5ftf/views/inputs-pledge-new-misc.php
@@ -12,11 +12,12 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 
 	<input
 		type="checkbox"
-		id="5ftf-pledge-agree"
-		name="pledge-agree"
+		id="5ftf-pledge-agreement"
+		name="pledge-agreement"
 		required
+		<?php checked( $data['pledge-agreement'] ); ?>
 	/>
-	<label for="5ftf-pledge-agree">
+	<label for="5ftf-pledge-agreement">
 		<?php esc_html_e( 'I agree', 'wordpressorg' ); ?>
 	</label>
 </div>


### PR DESCRIPTION
Ensures that a submission to the new pledge form has:

* A unique email address compared to existing pledges
* A unique domain in the URL, compared to existing pledges
* Has at least one valid contributor listed

Error messages when one or more of these conditions isn't met are descriptive so that the submitter can correct the issue.

Fixes #15 

**To test**

* Try submitting the form with a contributor username that does not actually exist in the user table, along with one that does. An error message should show listing the invalid user names.
* Try submitting the form with all valid values. A new pledge post should be created that contains all the relevant post meta values.

After successfully creating one pledge:

* Try creating a second pledge using the same email address. It should show you a descriptive error message and allow you to correct the form with all of your values still filled in.
* Try creating a second pledge using a website address with the same domain. Should be a similar error message and result to above.