### PR TITLE
Create a Pledge: Upload a logo

### DIFF
--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -333,9 +333,6 @@ function safelist_image_mimes( $mimes ) {
 		'jpg|jpeg|jpe' => 'image/jpeg',
 		'gif'          => 'image/gif',
 		'png'          => 'image/png',
-		'bmp'          => 'image/bmp',
-		'tiff|tif'     => 'image/tiff',
-		'ico'          => 'image/x-icon',
 	);
 }
 

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -108,6 +108,34 @@ function process_form_new() {
 		Contributor\create_new_contributor( $wporg_username, $new_pledge_id );
 	}
 
+	// Process image.
+	if ( ! function_exists('media_handle_upload') ) {
+		require_once( ABSPATH . 'wp-admin/includes/image.php' );
+		require_once( ABSPATH . 'wp-admin/includes/file.php' );
+		require_once( ABSPATH . 'wp-admin/includes/media.php' );
+	}
+
+	$logo = isset( $_FILES['org-logo'] ) ? $_FILES['org-logo'] : false;
+	if ( $logo ) {
+		if ( ! in_array( $logo['type'], [ 'image/png', 'image/jpg' ] ) ) {
+			return new WP_Error(
+				'invalid_image_type',
+				__( 'Logo file must be a png or jpg.', 'wporg' )
+			);
+		}
+		if ( ( $logo['size'] > 5 * MB_IN_BYTES ) ) {
+			return new WP_Error(
+				'invalid_image_size',
+				__( 'Logo file must be less than 5MB.', 'wporg' )
+			);
+		}
+
+		$result = \media_handle_sideload( $logo, $new_pledge_id );
+		if ( ! is_wp_error( $result ) ) {
+			set_post_thumbnail( $new_pledge_id, $result );
+		}
+	}
+
 	return 'success';
 }
 

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -61,19 +61,9 @@ function process_form_new() {
 		return $contributors;
 	}
 
-	// Process image.
-	if ( ! function_exists('media_handle_upload') ) {
-		require_once( ABSPATH . 'wp-admin/includes/image.php' );
-		require_once( ABSPATH . 'wp-admin/includes/file.php' );
-		require_once( ABSPATH . 'wp-admin/includes/media.php' );
-	}
-
-	$logo = isset( $_FILES['org-logo'] ) ? $_FILES['org-logo'] : false;
-	if ( $logo ) {
-		$logo_id = \media_handle_sideload( $logo, 0 );
-		if ( is_wp_error( $logo_id ) ) {
-			return $logo_id;
-		}
+	$logo_attachment_id = upload_image( $_FILES['org-logo'] );
+	if ( is_wp_error( $logo_attachment_id ) ) {
+		return $logo_attachment_id;
 	}
 
 	$name = sanitize_meta(
@@ -93,7 +83,12 @@ function process_form_new() {
 		Contributor\create_new_contributor( $wporg_username, $new_pledge_id );
 	}
 
-	set_post_thumbnail( $new_pledge_id, $logo_id );
+	// Attach logo to the pledge.
+	wp_update_post( array(
+		'ID'          => $logo_attachment_id,
+		'post_parent' => $new_pledge_id,
+	) );
+	set_post_thumbnail( $new_pledge_id, $logo_attachment_id );
 
 	return 'success';
 }
@@ -290,4 +285,65 @@ function validate_submission( $submission ) {
 	}
 
 	return false;
+}
+
+/**
+ * Upload the logo image into the media library.
+ *
+ * @param array $logo $_FILES array for the uploaded logo.
+ * @return int|WP_Error Upload attachment ID, or WP_Error if there was an error.
+ */
+function upload_image( $logo ) {
+	if ( ! $logo ) {
+		return false;
+	}
+
+	// Process image.
+	if ( ! function_exists('media_handle_upload') ) {
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+	}
+
+	if ( ! function_exists('check_upload_size') ) {
+		require_once ABSPATH . 'wp-includes/ms-functions.php';
+		require_once ABSPATH . 'wp-admin/includes/ms.php';
+	}
+
+	add_filter( 'upload_mimes', __NAMESPACE__ . '\safelist_image_mimes' );
+	add_filter( 'pre_site_option_fileupload_maxk', __NAMESPACE__ . '\restrict_file_size' );
+	add_filter( 'wp_handle_sideload_prefilter', 'check_upload_size' );
+
+	$logo_id = \media_handle_sideload( $logo, 0 );
+
+	remove_filter( 'upload_mimes', __NAMESPACE__ . '\safelist_image_mimes' );
+	remove_filter( 'pre_site_option_fileupload_maxk', __NAMESPACE__ . '\restrict_file_size' );
+	remove_filter( 'wp_handle_sideload_prefilter', 'check_upload_size' );
+
+	return $logo_id;
+}
+
+/**
+ * Only allow image mime types.
+ *
+ * @param array $mimes Mime types keyed by the file extension regex corresponding to those types.
+ */
+function safelist_image_mimes( $mimes ) {
+	return array(
+		'jpg|jpeg|jpe' => 'image/jpeg',
+		'gif'          => 'image/gif',
+		'png'          => 'image/png',
+		'bmp'          => 'image/bmp',
+		'tiff|tif'     => 'image/tiff',
+		'ico'          => 'image/x-icon',
+	);
+}
+
+/**
+ * Restrict images uploaded by this form to be less than 5MB.
+ *
+ * @param bool $value Null– returning a value will short-circuit the option lookup.
+ */
+function restrict_file_size( $value ) {
+	return 5 * MB_IN_BYTES;
 }

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -51,7 +51,7 @@ function render_form_new() {
  */
 function process_form_new() {
 	$submission = get_form_submission();
-	$has_error = validate_submission( $submission );
+	$has_error = check_invalid_submission( $submission );
 	if ( $has_error ) {
 		return $has_error;
 	}
@@ -132,7 +132,7 @@ function render_form_manage() {
  */
 function process_form_manage() {
 	$submission = get_form_submission();
-	$has_error = validate_submission( $submission );
+	$has_error = check_invalid_submission( $submission );
 	if ( $has_error ) {
 		return $has_error;
 	}
@@ -253,9 +253,9 @@ function parse_contributors( $contributors ) {
 /**
  * Check the submission for valid data.
  *
- * @return false|WP_Error
+ * @return false|WP_Error Return any errors in the submission, or false if no errors.
  */
-function validate_submission( $submission ) {
+function check_invalid_submission( $submission ) {
 	$has_required = PledgeMeta\has_required_pledge_meta( $submission );
 	if ( is_wp_error( $has_required ) ) {
 		return $has_required;

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -131,9 +131,10 @@ function process_form_new() {
 		}
 
 		$result = \media_handle_sideload( $logo, $new_pledge_id );
-		if ( ! is_wp_error( $result ) ) {
-			set_post_thumbnail( $new_pledge_id, $result );
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
+		set_post_thumbnail( $new_pledge_id, $result );
 	}
 
 	return 'success';

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -69,6 +69,12 @@ function get_pledge_meta_config( $context = '' ) {
 			'sanitize_callback' => 'sanitize_text_field',
 			'show_in_rest'      => false,
 		),
+		'org-logo'              => array(
+			'single'            => true,
+			'sanitize_callback' => 'esc_url_raw',
+			'show_in_rest'      => true,
+			'php_filter'        => FILTER_VALIDATE_URL,
+		),
 		'pledge-email-confirmed' => array(
 			'single'            => true,
 			'sanitize_callback' => 'wp_validate_boolean',

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -69,12 +69,6 @@ function get_pledge_meta_config( $context = '' ) {
 			'sanitize_callback' => 'sanitize_text_field',
 			'show_in_rest'      => false,
 		),
-		'org-logo'              => array(
-			'single'            => true,
-			'sanitize_callback' => 'esc_url_raw',
-			'show_in_rest'      => true,
-			'php_filter'        => FILTER_VALIDATE_URL,
-		),
 		'pledge-email-confirmed' => array(
 			'single'            => true,
 			'sanitize_callback' => 'wp_validate_boolean',
@@ -229,27 +223,6 @@ function save_pledge( $pledge_id, $pledge ) {
  */
 function save_pledge_meta( $pledge_id, $new_values ) {
 	$config = get_pledge_meta_config();
-
-	// Process image.
-	if ( ! function_exists('media_handle_upload') ) {
-		require_once( ABSPATH . 'wp-admin/includes/image.php' );
-		require_once( ABSPATH . 'wp-admin/includes/file.php' );
-		require_once( ABSPATH . 'wp-admin/includes/media.php' );
-	}
-
-	$logo = isset( $_FILES['org-logo'] ) ? $_FILES['org-logo'] : false;
-	if (
-		$logo &&
-		in_array( $logo['type'], [ 'image/png', 'image/jpg' ] ) &&
-		( $logo['size'] < 5 * MB_IN_BYTES )
-	) {
-		$result = \media_handle_sideload( $logo, $pledge_id );
-
-		if ( ! is_wp_error( $result ) ) {
-			$new_values['org-logo'] = wp_get_attachment_url( $result );
-			set_post_thumbnail( $pledge_id, $result );
-		}
-	}
 
 	foreach ( $new_values as $key => $value ) {
 		if ( array_key_exists( $key, $config ) ) {

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -230,6 +230,27 @@ function save_pledge( $pledge_id, $pledge ) {
 function save_pledge_meta( $pledge_id, $new_values ) {
 	$config = get_pledge_meta_config();
 
+	// Process image.
+	if ( ! function_exists('media_handle_upload') ) {
+		require_once( ABSPATH . 'wp-admin/includes/image.php' );
+		require_once( ABSPATH . 'wp-admin/includes/file.php' );
+		require_once( ABSPATH . 'wp-admin/includes/media.php' );
+	}
+
+	$logo = isset( $_FILES['org-logo'] ) ? $_FILES['org-logo'] : false;
+	if (
+		$logo &&
+		in_array( $logo['type'], [ 'image/png', 'image/jpg' ] ) &&
+		( $logo['size'] < 5 * MB_IN_BYTES )
+	) {
+		$result = \media_handle_sideload( $logo, $pledge_id );
+
+		if ( ! is_wp_error( $result ) ) {
+			$new_values['org-logo'] = wp_get_attachment_url( $result );
+			set_post_thumbnail( $pledge_id, $result );
+		}
+	}
+
 	foreach ( $new_values as $key => $value ) {
 		if ( array_key_exists( $key, $config ) ) {
 			$meta_key = META_PREFIX . $key;

--- a/plugins/wporg-5ftf/views/form-pledge-manage.php
+++ b/plugins/wporg-5ftf/views/form-pledge-manage.php
@@ -7,7 +7,7 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 /** @var bool  $updated */
 ?>
 
-<form class="pledge-form" id="5ftf-form-pledge-manage" action="" method="post">
+<form class="pledge-form" id="5ftf-form-pledge-manage" action="" method="post" enctype="multipart/form-data">
 	<?php
 	require get_views_path() . 'inputs-pledge-org-info.php';
 	require get_views_path() . 'manage-contributors.php';

--- a/plugins/wporg-5ftf/views/form-pledge-new.php
+++ b/plugins/wporg-5ftf/views/form-pledge-new.php
@@ -48,7 +48,7 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 
 <?php else : ?>
 
-	<form class="pledge-form" id="5ftf-form-pledge-new" action="" method="post">
+	<form class="pledge-form" id="5ftf-form-pledge-new" action="" method="post" enctype="multipart/form-data">
 		<?php
 		require get_views_path() . 'inputs-pledge-org-info.php';
 		require get_views_path() . 'inputs-pledge-contributors.php';

--- a/plugins/wporg-5ftf/views/inputs-pledge-org-info.php
+++ b/plugins/wporg-5ftf/views/inputs-pledge-org-info.php
@@ -24,7 +24,11 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 		<?php esc_html_e( 'Logo', 'wordpressorg' ); ?>
 	</label>
 	<br />
-	<?php /* @todo Display existing logo here */ ?>
+	<?php if ( is_admin() && has_post_thumbnail() ) : ?>
+		<div class="form-field__logo-display">
+			<?php the_post_thumbnail(); ?>
+		</div>
+	<?php endif; ?>
 	<input
 		type="file"
 		id="5ftf-org-logo"


### PR DESCRIPTION
Update the pledge form to allow an image upload. The image is restricted to png or jpg, less than 5MB - but currently a logo is not required. If successful, the image is added as the featured image for the pledge.

Locally, I can't seem to upload a file larger than 1MB, without hitting "Request Entity Too Large", but the limit does still work.

I'd especially like a  👀 from @iandunn for any security issues, since we're allowing open file uploads - should I be doing more to check if the image is really what it claims to be?