### PR TITLE
Pledges: Move contributor management UI to separate file

### DIFF
--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -168,7 +168,7 @@ function render_meta_boxes( $pledge, $box ) {
 			break;
 
 		case 'pledge-contributors':
-			require FiveForTheFuture\get_views_path() . 'inputs-pledge-contributors.php';
+			require FiveForTheFuture\get_views_path() . 'manage-contributors.php';
 			break;
 	}
 

--- a/plugins/wporg-5ftf/views/form-pledge-manage.php
+++ b/plugins/wporg-5ftf/views/form-pledge-manage.php
@@ -10,7 +10,7 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 <form class="pledge-form" id="5ftf-form-pledge-manage" action="" method="post">
 	<?php
 	require get_views_path() . 'inputs-pledge-org-info.php';
-	require get_views_path() . 'inputs-pledge-contributors.php';
+	require get_views_path() . 'manage-contributors.php';
 	require get_views_path() . 'inputs-pledge-org-email.php';
 	?>
 

--- a/plugins/wporg-5ftf/views/inputs-pledge-contributors.php
+++ b/plugins/wporg-5ftf/views/inputs-pledge-contributors.php
@@ -1,12 +1,9 @@
 <?php
 namespace WordPressDotOrg\FiveForTheFuture\View;
 
-/** @var array $contributors */
 /** @var array $data */
 /** @var bool  $readonly */
 ?>
-
-<?php if ( empty( $contributors ) ) : ?>
 
 <div class="form-field">
 	<label for="5ftf-pledge-contributors">
@@ -24,53 +21,3 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 		<?php esc_html_e( 'Separate each username with a comma.', 'wordpressorg' ); ?>
 	</p>
 </div>
-
-<?php else : ?>
-
-<div class="5ftf-contributors">
-	<?php foreach ( $contributors as $contributor_status => $group ) : ?>
-		<?php if ( ! empty( $group ) ) : ?>
-			<h3 class="contributor-list-heading">
-				<?php
-				switch ( $contributor_status ) {
-					case 'pending':
-						esc_html_e( 'Unconfirmed', 'wporg' );
-						break;
-					case 'publish':
-						esc_html_e( 'Confirmed', 'wporg' );
-						break;
-				}
-				?>
-			</h3>
-
-			<ul class="contributor-list <?php echo esc_attr( $contributor_status ); ?>">
-				<?php foreach ( $group as $contributor_post ) :
-					$contributor = get_user_by( 'login', $contributor_post->post_title );
-					?>
-					<li>
-						<?php echo get_avatar( $contributor->user_email, 32 ); ?>
-						<?php echo esc_html( $contributor_post->post_title ); ?>
-						<!-- TODO These buttons don't do anything yet.
-						<button class="button-primary" data-action="remove" data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>">
-							<?php esc_html_e( 'Remove', 'wporg' ); ?>
-						</button>
-						<?php if ( 'pending' === $contributor_post->post_status ) : ?>
-							<button class="button-secondary" data-action="resend-confirmation" data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>">
-								<?php esc_html_e( 'Resend confirmation', 'wporg' ); ?>
-							</button>
-						<?php endif; ?>
-						-->
-					</li>
-				<?php endforeach; ?>
-			</ul>
-		<?php endif; ?>
-	<?php endforeach; ?>
-
-	<!-- TODO This button doesn't do anything yet.
-	<button class="button-primary" data-action="add-contributor">
-		<?php esc_html_e( 'Add new contributor', 'wporg' ); ?>
-	</button>
-	-->
-</div>
-
-<?php endif; ?>

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -1,0 +1,57 @@
+<?php
+namespace WordPressDotOrg\FiveForTheFuture\View;
+
+/** @var array $contributors */
+/** @var array $data */
+/** @var bool  $readonly */
+?>
+
+<div class="5ftf-contributors">
+	<?php if ( ! empty( $contributors ) ) : ?>
+		<?php foreach ( $contributors as $contributor_status => $group ) : ?>
+			<?php if ( ! empty( $group ) ) : ?>
+				<h3 class="contributor-list-heading">
+					<?php
+					switch ( $contributor_status ) {
+						case 'pending':
+							esc_html_e( 'Unconfirmed', 'wporg' );
+							break;
+						case 'publish':
+							esc_html_e( 'Confirmed', 'wporg' );
+							break;
+					}
+					?>
+				</h3>
+
+				<ul class="contributor-list <?php echo esc_attr( $contributor_status ); ?>">
+					<?php foreach ( $group as $contributor_post ) :
+						$contributor = get_user_by( 'login', $contributor_post->post_title );
+						?>
+						<li>
+							<?php echo get_avatar( $contributor->user_email, 32 ); ?>
+							<?php echo esc_html( $contributor_post->post_title ); ?>
+							<!-- TODO These buttons don't do anything yet.
+							<button class="button-primary" data-action="remove" data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>">
+								<?php esc_html_e( 'Remove', 'wporg' ); ?>
+							</button>
+							<?php if ( 'pending' === $contributor_post->post_status ) : ?>
+								<button class="button-secondary" data-action="resend-confirmation" data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>">
+									<?php esc_html_e( 'Resend confirmation', 'wporg' ); ?>
+								</button>
+							<?php endif; ?>
+							-->
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			<?php endif; ?>
+		<?php endforeach; ?>
+	<?php else : ?>
+		<p><?php esc_html_e( 'There are no contributors added to this pledge yet.', 'wporg' ); ?></p>
+	<?php endif; ?>
+
+	<!-- TODO This button doesn't do anything yet.
+	<button class="button-primary" data-action="add-contributor">
+		<?php esc_html_e( 'Add new contributor', 'wporg' ); ?>
+	</button>
+	-->
+</div>


### PR DESCRIPTION
Having both the input for adding a comma separated list of contributors
to a new pledge and the UI for managing the contributors on an existing
pledge in the same file was confusing and it conflated two different
pieces of functionality. It also caused `undefined index` errors in some
views  because `'pledge-contributors'` only exists when submitting the
new pledge form.