### PR TITLE
Disallow create_posts for the Pledges CPT

### DIFF
--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -65,6 +65,10 @@ function register_custom_post_type() {
 		'exclude_from_search' => true,
 		'publicly_queryable'  => false,
 		'capability_type'     => 'page',
+		'capabilities'        => array(
+			'create_posts' => 'do_not_allow'
+		),
+		'map_meta_cap'        => true,
 		'show_in_rest'        => false, // todo Maybe turn this on later.
 	);
 

--- a/plugins/wporg-5ftf/includes/pledge.php
+++ b/plugins/wporg-5ftf/includes/pledge.php
@@ -94,6 +94,10 @@ function register_custom_post_type() {
 		'exclude_from_search' => true,
 		'publicly_queryable'  => true,
 		'capability_type'     => 'page',
+		'capabilities'        => array(
+			'create_posts' => 'do_not_allow'
+		),
+		'map_meta_cap'        => true,
 		'show_in_rest'        => false, // todo Maybe turn this on later.
 	);
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/five-for-the-future/issues/77

Remove the ability to "Add New" pledges from the admin as it causes fatal errors. We want to force all new submissions through the frontend form.

The `map_meta_cap` part is necessary to allow for editing still, due to `create_posts` being a primitive capability.

More info here: https://codex.wordpress.org/Function_Reference/register_post_type

> There are also eight other primitive capabilities which are not referenced directly in core, except in map_meta_cap(), which takes the three aforementioned meta capabilities and translates them into one or more primitive capabilities that must then be checked against the user or role, depending on the context. These additional capabilities are only used in map_meta_cap(). Thus, they are only assigned by default if the post type is registered with the 'map_meta_cap' argument set to true (default is false).