### PR TITLE
Add bbPress and BuddyPress

### DIFF
--- a/themes/wporg-5ftf/css/components/_team-badges.scss
+++ b/themes/wporg-5ftf/css/components/_team-badges.scss
@@ -7,7 +7,7 @@
 	flex-wrap: wrap;
 	margin: 0;
 	list-style: none;
-	
+
 	li {
 		display: flex;
 		align-items: center;
@@ -193,4 +193,20 @@
 }
 .badge-test-team:before {
 	color: rgb(136, 79, 174);
+}
+
+.badge-bbpress {
+	background: rgba(45, 142, 66, 0.25);
+	box-shadow: 0 0 0 4px rgb(45, 142, 66);
+}
+.badge-bbpress:before {
+	color: rgb(45, 142, 66);
+}
+
+.badge-buddypress {
+	background: rgba(216, 72, 0, 0.25);
+	box-shadow: 0 0 0 4px rgb(216, 72, 0);
+}
+.badge-buddypress:before {
+	color: rgb(216, 72, 0);
 }

--- a/themes/wporg-5ftf/functions.php
+++ b/themes/wporg-5ftf/functions.php
@@ -224,6 +224,14 @@ function get_badge_classes( $team ) {
 			$classes = array( 'badge-accessibility', 'dashicons-universal-access' );
 			break;
 
+		case 'bbpress':
+			$classes = array( 'badge-bbpress', 'dashicons-buddicons-bbpress-logo' );
+			break;
+
+		case 'buddypress':
+			$classes = array( 'badge-buddypress', 'dashicons-buddicons-buddypress-logo' );
+			break;
+
 		case 'cli':
 			$classes = array( 'badge-wp-cli', 'dashicons-arrow-right-alt2' );
 			break;


### PR DESCRIPTION
This PR adds the bbPress and BuddyPress badge colours.

I couldn't find where the code was to update the dropdown to select bbPress or BuddyPress though, I'm thinking that code is in the private dotorg _profiles_ codebase:

e.g.: https://profiles.wordpress.org/netweb/profile/edit/group/5/

<img width="181" alt="image" src="https://user-images.githubusercontent.com/1016458/68258142-b61e5600-0070-11ea-905d-5983ee144aee.png">
