### PR TITLE
Add more exclusions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,12 @@
 mu-plugins/vendor
 node_modules
 
-plugins/gutenberg
-plugins/wordpress-importer
+plugins/*
+!plugins/wporg-5ftf
 
 themes/wporg-5ftf/css/style.css
 themes/wporg-5ftf/css/style-editor.css
 themes/pub
+
+/uploads
+/db.php


### PR DESCRIPTION
Exclude everthing in `plugins/` except for `wporg-5ftf`. This makes it easier to add development-specific plugins like query monitor without needing to make local exceptions.

Additionally exclude the `uploads` folder and `db.php` which can both be present in a normal `wp-content` folder.