### PR TITLE
Clean up contributor pledge form processing

### DIFF
--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -306,11 +306,15 @@ function render_my_pledges() {
  * @return string
  */
 function process_my_pledges_form() {
-	$message             = '';
-	$status              = false;
 	$contributor_post_id = filter_input( INPUT_POST, 'contributor_post_id', FILTER_VALIDATE_INT );
-	$pledge              = get_post( get_post( $contributor_post_id )->post_parent );
 	$nonce               = filter_input( INPUT_POST, '_wpnonce', FILTER_SANITIZE_STRING );
+	if ( empty( $contributor_post_id ) || empty( $nonce ) ) {
+		return '';
+	}
+
+	$message = '';
+	$status  = false;
+	$pledge  = get_post( get_post( $contributor_post_id )->post_parent );
 
 	if ( filter_input( INPUT_POST, 'join_organization' ) ) {
 		wp_verify_nonce( $nonce, 'join_decline_organization' ) || wp_nonce_ays( 'join_decline_organization' );

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -322,19 +322,19 @@ function process_my_pledges_form() {
 	$message = '';
 	$status  = false;
 	if ( filter_input( INPUT_POST, 'join_organization' ) ) {
-		wp_verify_nonce( $nonce, 'join_decline_organization' ) || wp_nonce_ays( 'join_decline_organization' );
+		wp_verify_nonce( $nonce, 'join_decline_organization_' . $contributor_post_id ) || wp_nonce_ays( 'join_decline_organization' );
 
 		$status  = 'publish';
 		$message = "You have joined the pledge from {$pledge->post_title}.";
 
 	} elseif ( filter_input( INPUT_POST, 'decline_invitation' ) ) {
-		wp_verify_nonce( $nonce, 'join_decline_organization' ) || wp_nonce_ays( 'join_decline_organization' );
+		wp_verify_nonce( $nonce, 'join_decline_organization_' . $contributor_post_id ) || wp_nonce_ays( 'join_decline_organization' );
 
 		$status  = 'trash';
 		$message = "You have declined the pledge invitation from {$pledge->post_title}.";
 
 	} elseif ( filter_input( INPUT_POST, 'leave_organization' ) ) {
-		wp_verify_nonce( $nonce, 'leave_organization' ) || wp_nonce_ays( 'leave_organization' );
+		wp_verify_nonce( $nonce, 'leave_organization_' . $contributor_post_id ) || wp_nonce_ays( 'leave_organization' );
 
 		$status  = 'trash';
 		$message = "You have left the {$pledge->post_title} pledge.";

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -309,13 +309,18 @@ function process_my_pledges_form() {
 	$contributor_post_id = filter_input( INPUT_POST, 'contributor_post_id', FILTER_VALIDATE_INT );
 	$nonce               = filter_input( INPUT_POST, '_wpnonce', FILTER_SANITIZE_STRING );
 	if ( empty( $contributor_post_id ) || empty( $nonce ) ) {
-		return '';
+		return ''; // Return early, the form wasn't submitted.
+	}
+
+	$contributor_post = get_post( $contributor_post_id );
+	if ( isset( $contributor_post->post_type ) && $contributor_post->post_type === CPT_ID ) {
+		$pledge = get_post( $contributor_post->post_parent );
+	} else {
+		return ''; // Return early, the form was submitted incorrectly.
 	}
 
 	$message = '';
 	$status  = false;
-	$pledge  = get_post( get_post( $contributor_post_id )->post_parent );
-
 	if ( filter_input( INPUT_POST, 'join_organization' ) ) {
 		wp_verify_nonce( $nonce, 'join_decline_organization' ) || wp_nonce_ays( 'join_decline_organization' );
 

--- a/plugins/wporg-5ftf/views/single-my-pledge.php
+++ b/plugins/wporg-5ftf/views/single-my-pledge.php
@@ -44,7 +44,7 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 			<input type="hidden" name="contributor_post_id" value="<?php echo esc_attr( $contributor_post->ID ); ?>" />
 
 			<?php if ( 'pending' === $contributor_post->post_status ) : ?>
-				<?php wp_nonce_field( 'join_decline_organization' ); ?>
+				<?php wp_nonce_field( 'join_decline_organization_' . $contributor_post->ID ); ?>
 
 				<input
 					type="submit"
@@ -61,7 +61,7 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 				/>
 
 			<?php elseif ( 'publish' === $contributor_post->post_status ) : ?>
-				<?php wp_nonce_field( 'leave_organization' ); ?>
+				<?php wp_nonce_field( 'leave_organization_' . $contributor_post->ID ); ?>
 
 				<input
 					type="submit"


### PR DESCRIPTION
### Changes

1) Prevent two unnecessary queries when `/my-pledges/` is first loaded. `get_post()` will default to loading the global $post_id if it's passed `null`, which it was/is.

2) Ensure the `$contributor_post_id` is of the valid post type.

3) Append the related object ID to the nonce to make it a more unique.

### Testing

After applying this patch, add your user to a new pledge and go to `/my-pledges/` and ensure you can still accept, decline, and later leave the organization's pledge.