### PR TITLE
Verify contributor form updates are valid for the current user

### DIFF
--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -347,13 +347,13 @@ function process_my_pledges_form() {
 		$message = "You have left the {$pledge->post_title} pledge.";
 	}
 
-	if ( 'publish' === $status ) {
+	if ( 'publish' === $status && 'publish' !== $contributor_post->post_status ) {
 		wp_update_post( array(
-			'ID'          => $contributor_post_id,
+			'ID'          => $contributor_post->ID,
 			'post_status' => $status,
 		) );
-	} elseif ( 'trash' === $status ) {
-		remove_contributor( $contributor_post_id );
+	} elseif ( 'trash' === $status && 'trash' !== $contributor_post->post_status ) {
+		remove_contributor( $contributor_post->ID );
 	}
 
 	return $message;

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -313,17 +313,20 @@ function process_my_pledges_form() {
 	}
 
 	$contributor_post = get_post( $contributor_post_id );
-	if ( isset( $contributor_post->post_type ) && $contributor_post->post_type === CPT_ID ) {
-		$pledge = get_post( $contributor_post->post_parent );
-	} else {
+	if ( ! isset( $contributor_post->post_type ) || $contributor_post->post_type !== CPT_ID ) {
 		return ''; // Return early, the form was submitted incorrectly.
 	}
 
+	$current_user = wp_get_current_user();
+	if ( ! isset( $current_user->user_login ) || $contributor_post->post_title !== $current_user->user_login ) {
+		return ''; // User doesn't have permission to update this.
+	}
+
+	$pledge  = get_post( $contributor_post->post_parent );
 	$message = '';
 	$status  = false;
 	if ( filter_input( INPUT_POST, 'join_organization' ) ) {
 		$nonce_action = 'join_decline_organization_' . $contributor_post_id;
-
 		wp_verify_nonce( $unverified_nonce, $nonce_action ) || wp_nonce_ays( $nonce_action );
 
 		$status  = 'publish';


### PR DESCRIPTION
1. Add an extra check before processing the contributor form. The current user's username will match with the contributor's post title if it belongs to them.
2. Only trigger `wp_update_post()` / `remove_contributor()` actions and hooks when actually needed. Atm a user could spam them by refreshing the page after a form submission.

Once caveat to the user check is that WPorg usernames could be updated at some point (which is rare but does happen). Worst case, the user in question would need to have the pledges manually updated for them.

Alternatively, we could store the user's ID on the contributor post, perhaps as the post_author. I'm not 100% sure if there are any security concerns with this, though I don't believe so. Additionally, we would need to create a script to backfill all the existing data on the site. Right now, the plugin/theme just uses `get_user_by( 'login', $post->post_title )` a bunch which isn't too inefficient. I'd say we could hold off on the data change for now, as we can always go back and update the post's with a post_author if a specific query/feature would widely benefit.

CC @iandunn 