### PR TITLE
Manage a Pledge: Enable adding/removing contributors from wp-admin.

### DIFF
--- a/plugins/wporg-5ftf/assets/css/admin.css
+++ b/plugins/wporg-5ftf/assets/css/admin.css
@@ -32,6 +32,14 @@
 	line-height: 1;
 }
 
-.pledge-form .form-field__agree label {
-	margin-bottom: 0;
+.pledge-form .form-field .email-status {
+	font-size: 1.1em;
+}
+
+.pledge-form .email-status.is-confirmed {
+	color: #297531;
+}
+
+.pledge-form .email-status.is-unconfirmed {
+	color: #c92c2c;
 }

--- a/plugins/wporg-5ftf/assets/css/admin.css
+++ b/plugins/wporg-5ftf/assets/css/admin.css
@@ -52,6 +52,10 @@
 	margin-bottom: 1.5rem;
 }
 
+.pledge-contributors.pledge-status__draft .resend-confirm {
+	display: none;
+}
+
 .contributor-list th,
 .contributor-list td,
 .contributor-list th *,

--- a/plugins/wporg-5ftf/assets/css/admin.css
+++ b/plugins/wporg-5ftf/assets/css/admin.css
@@ -50,7 +50,6 @@
 
 .pledge-form .contributor-list {
 	margin-bottom: 1.5rem;
-	table-layout: fixed;
 }
 
 .contributor-list th,
@@ -62,10 +61,6 @@
 
 .contributor-list .avatar {
 	margin-right: 8px;
-}
-
-.contributor-list .contributor-list__name {
-	font-size: 1.1em;
 }
 
 .contributor-list .button-link-delete {

--- a/plugins/wporg-5ftf/assets/css/admin.css
+++ b/plugins/wporg-5ftf/assets/css/admin.css
@@ -43,3 +43,24 @@
 .pledge-form .email-status.is-unconfirmed {
 	color: #c92c2c;
 }
+
+.contributor-list li * {
+	vertical-align: middle;
+}
+
+.contributor-list .button-link-delete {
+	text-decoration: none;
+	margin-right: 8px;
+}
+
+.contributor-list .avatar {
+	margin-right: 8px;
+}
+
+.contributor-list .contributor-list__name {
+	font-size: 1.1em;
+}
+
+.contributor-list .button {
+	float: right;
+}

--- a/plugins/wporg-5ftf/assets/css/admin.css
+++ b/plugins/wporg-5ftf/assets/css/admin.css
@@ -7,17 +7,17 @@
 	display: inline-block;
 }
 
-.pledge-form .form-field input[type=text],
-.pledge-form .form-field input[type=url],
-.pledge-form .form-field input[type=number],
-.pledge-form .form-field input[type=email],
+.pledge-form .form-field input[type="text"],
+.pledge-form .form-field input[type="url"],
+.pledge-form .form-field input[type="number"],
+.pledge-form .form-field input[type="email"],
 .pledge-form .form-field textarea {
 	display: block;
 	width: 100%;
 	padding: 8px;
 }
 
-.pledge-form .form-field input[type=number] {
+.pledge-form .form-field input[type="number"] {
 	max-width: 10em;
 	height: auto;
 }
@@ -44,13 +44,20 @@
 	color: #c92c2c;
 }
 
-.contributor-list li * {
-	vertical-align: middle;
+.pledge-form .contributor-list-heading {
+	margin: 1rem 0;
 }
 
-.contributor-list .button-link-delete {
-	text-decoration: none;
-	margin-right: 8px;
+.pledge-form .contributor-list {
+	margin-bottom: 1.5rem;
+	table-layout: fixed;
+}
+
+.contributor-list th,
+.contributor-list td,
+.contributor-list th *,
+.contributor-list td * {
+	vertical-align: middle;
 }
 
 .contributor-list .avatar {
@@ -61,6 +68,10 @@
 	font-size: 1.1em;
 }
 
-.contributor-list .button {
-	float: right;
+.contributor-list .button-link-delete {
+	text-decoration: none;
+}
+
+.contributor-list .button-link-delete .dashicons {
+	margin-top: -2px;
 }

--- a/plugins/wporg-5ftf/assets/js/admin.js
+++ b/plugins/wporg-5ftf/assets/js/admin.js
@@ -1,7 +1,66 @@
-/* global ajaxurl, FiveForTheFuture, jQuery */
+/* global ajaxurl, FiveForTheFuture, fftfContributors, jQuery */
 /* eslint no-alert: "off" */
 jQuery( document ).ready( function( $ ) {
+	/**
+	 * Render the contributor lists using the contributors template into the pledge-contributors container. This
+	 * uses `_renderContributors` to render a list of contributors per status (published, pending).
+	 *
+	 * @param {Object} contributors - An object listing all contributors on a pledge.
+	 * @param {Object[]} contributors.publish - The list of published/confirmed contributors.
+	 * @param {Object[]} contributors.pending - The list of pending/unconfirmed contributors.
+	 * @param {Object} container - The parent container for this section.
+	 */
+	function render( contributors, container ) {
+		const listContainer = container.querySelector( '.pledge-contributors' );
+		const template = wp.template( '5ftf-contributor-lists' );
+		const data = {
+			publish: _renderContributors( contributors.publish ),
+			pending: _renderContributors( contributors.pending ),
+		};
+		$( listContainer ).html( template( data ) );
+	}
+
+	/**
+	 * Render a given contributor list using the contributor template.
+	 *
+	 * @param {Object[]} contributors - An array of contributor data objects.
+	 * @return {string} An HTML string of contributors.
+	 */
+	function _renderContributors( contributors ) {
+		if ( ! contributors ) {
+			return [];
+		}
+		const template = wp.template( '5ftf-contributor' );
+		return contributors.map( template ).join( '' );
+	}
+
+	/**
+	 * The default callback for AJAX actions.
+	 *
+	 * @param {Object} response - An array of contributor data objects.
+	 * @param {string} response.message - An optional message to display to the user.
+	 * @param {Object[]} response.contributors - The new list of contributors.
+	 */
+	function defaultCallback( response ) {
+		if ( response.message ) {
+			alert( response.message );
+		}
+		if ( response.contributors ) {
+			render( response.contributors, container );
+		}
+	}
+
+	/**
+	 * Send an ajax request using the `manage_contributors` action. This function also automatically adds the
+	 * nonce, which should be defined in the global FiveForTheFuture variable.
+	 *
+	 * @param {Object} data - A list of data to send to the endpoint.
+	 * @param {Function} callback - A function to be called when the request completes.
+	 */
 	function sendAjaxRequest( data, callback ) {
+		if ( ! callback ) {
+			callback = defaultCallback;
+		}
 		$.ajax( {
 			type: 'POST',
 			url: ajaxurl,
@@ -14,7 +73,9 @@ jQuery( document ).ready( function( $ ) {
 		} );
 	}
 
+	// Initialize.
 	const container = document.getElementById( '5ftf-contributors' );
+	render( fftfContributors, container );
 
 	// Remove Contributor button action.
 	$( container ).on( 'click', '[data-action="remove-contributor"]', function( event ) {
@@ -28,13 +89,6 @@ jQuery( document ).ready( function( $ ) {
 				pledge_id: data.pledgePost || 0,
 				contributor_id: data.contributorPost || 0,
 				manage_action: data.action || '',
-			}, function( response ) {
-				if ( response.message ) {
-					alert( response.message );
-				}
-				if ( response.success ) {
-					$( event.currentTarget ).closest( 'li' ).remove();
-				}
 			} );
 		}
 	} );
@@ -48,10 +102,6 @@ jQuery( document ).ready( function( $ ) {
 			pledge_id: data.pledgePost || 0,
 			contributor_id: data.contributorPost || 0,
 			manage_action: data.action || '',
-		}, function( response ) {
-			if ( response.message ) {
-				alert( response.message );
-			}
 		} );
 	} );
 } );

--- a/plugins/wporg-5ftf/assets/js/admin.js
+++ b/plugins/wporg-5ftf/assets/js/admin.js
@@ -1,0 +1,28 @@
+/* global ajaxurl, FiveForTheFuture_ManageNonce, jQuery */
+/* eslint no-alert: "off" */
+jQuery( document ).ready( function( $ ) {
+	function sendAjaxRequest( data, callback ) {
+		$.ajax( {
+			type: 'POST',
+			url: ajaxurl,
+			data: {
+				action: 'manage_contributors',
+				pledge_id: data.pledgePost || 0,
+				contributor_id: data.contributorPost || 0,
+				manage_action: data.action || '',
+				_ajax_nonce: FiveForTheFuture_ManageNonce,
+			},
+			success: callback,
+			dataType: 'json',
+		} );
+	}
+
+	$( '.contributor-list [data-action="resend-contributor-confirmation"]' ).click( function( event ) {
+		event.preventDefault();
+		sendAjaxRequest( event.currentTarget.dataset, function( response ) {
+			if ( response.message ) {
+				alert( response.message );
+			}
+		} );
+	} );
+} );

--- a/plugins/wporg-5ftf/assets/js/admin.js
+++ b/plugins/wporg-5ftf/assets/js/admin.js
@@ -1,25 +1,54 @@
-/* global ajaxurl, FiveForTheFuture_ManageNonce, jQuery */
+/* global ajaxurl, FiveForTheFuture, jQuery */
 /* eslint no-alert: "off" */
 jQuery( document ).ready( function( $ ) {
 	function sendAjaxRequest( data, callback ) {
 		$.ajax( {
 			type: 'POST',
 			url: ajaxurl,
-			data: {
+			data: Object.assign( {
 				action: 'manage_contributors',
-				pledge_id: data.pledgePost || 0,
-				contributor_id: data.contributorPost || 0,
-				manage_action: data.action || '',
-				_ajax_nonce: FiveForTheFuture_ManageNonce,
-			},
+				_ajax_nonce: FiveForTheFuture.manageNonce,
+			}, data ),
 			success: callback,
 			dataType: 'json',
 		} );
 	}
 
-	$( '.contributor-list [data-action="resend-contributor-confirmation"]' ).click( function( event ) {
+	const container = document.getElementById( '5ftf-contributors' );
+
+	// Remove Contributor button action.
+	$( container ).on( 'click', '[data-action="remove-contributor"]', function( event ) {
 		event.preventDefault();
-		sendAjaxRequest( event.currentTarget.dataset, function( response ) {
+
+		const confirmMsg = event.currentTarget.dataset.confirm;
+		if ( confirmMsg && confirm( confirmMsg ) ) {
+			const data = event.currentTarget.dataset;
+
+			sendAjaxRequest( {
+				pledge_id: data.pledgePost || 0,
+				contributor_id: data.contributorPost || 0,
+				manage_action: data.action || '',
+			}, function( response ) {
+				if ( response.message ) {
+					alert( response.message );
+				}
+				if ( response.success ) {
+					$( event.currentTarget ).closest( 'li' ).remove();
+				}
+			} );
+		}
+	} );
+
+	// Resend Contributor Confirmation button action.
+	$( container ).on( 'click', '[data-action="resend-contributor-confirmation"]', function( event ) {
+		event.preventDefault();
+		const data = event.currentTarget.dataset;
+
+		sendAjaxRequest( {
+			pledge_id: data.pledgePost || 0,
+			contributor_id: data.contributorPost || 0,
+			manage_action: data.action || '',
+		}, function( response ) {
 			if ( response.message ) {
 				alert( response.message );
 			}

--- a/plugins/wporg-5ftf/assets/js/admin.js
+++ b/plugins/wporg-5ftf/assets/js/admin.js
@@ -51,7 +51,7 @@ jQuery( document ).ready( function( $ ) {
 	}
 
 	/**
-	 * Send an ajax request using the `manage_contributors` action. This function also automatically adds the
+	 * Send an ajax request using the `manage-contributors` action. This function also automatically adds the
 	 * nonce, which should be defined in the global FiveForTheFuture variable.
 	 *
 	 * @param {Object} data - A list of data to send to the endpoint.
@@ -65,7 +65,7 @@ jQuery( document ).ready( function( $ ) {
 			type: 'POST',
 			url: ajaxurl,
 			data: Object.assign( {
-				action: 'manage_contributors',
+				action: 'manage-contributors',
 				pledge_id: FiveForTheFuture.pledgeId,
 				_ajax_nonce: FiveForTheFuture.manageNonce,
 			}, data ),

--- a/plugins/wporg-5ftf/assets/js/admin.js
+++ b/plugins/wporg-5ftf/assets/js/admin.js
@@ -66,10 +66,38 @@ jQuery( document ).ready( function( $ ) {
 			url: ajaxurl,
 			data: Object.assign( {
 				action: 'manage_contributors',
+				pledge_id: FiveForTheFuture.pledgeId,
 				_ajax_nonce: FiveForTheFuture.manageNonce,
 			}, data ),
 			success: callback,
 			dataType: 'json',
+		} );
+	}
+
+	/**
+	 * Send off the AJAX request with contributors pulled from the contributor text field.
+	 */
+	function _addContributors() {
+		const contribs = $( '#5ftf-pledge-contributors' ).val();
+		if ( ! contribs.length ) {
+			return;
+		}
+
+		sendAjaxRequest( {
+			contributors: contribs,
+			manage_action: 'add-contributor',
+		}, function( response ) {
+			if ( ! response.success ) {
+				const $message = $( '<div>' )
+					.attr( 'id', 'add-contrib-message' )
+					.addClass( 'notice notice-error notice-alt' )
+					.html( '<p>' + response.message + '</p>' );
+
+				$( '#add-contrib-message' ).replaceWith( $message );
+			} else if ( response.contributors ) {
+				render( response.contributors, container );
+				$( '#5ftf-pledge-contributors' ).val( '' );
+			}
 		} );
 	}
 
@@ -86,7 +114,6 @@ jQuery( document ).ready( function( $ ) {
 			const data = event.currentTarget.dataset;
 
 			sendAjaxRequest( {
-				pledge_id: data.pledgePost || 0,
 				contributor_id: data.contributorPost || 0,
 				manage_action: data.action || '',
 			} );
@@ -99,9 +126,22 @@ jQuery( document ).ready( function( $ ) {
 		const data = event.currentTarget.dataset;
 
 		sendAjaxRequest( {
-			pledge_id: data.pledgePost || 0,
 			contributor_id: data.contributorPost || 0,
 			manage_action: data.action || '',
 		} );
+	} );
+
+	// Add Contributor button action.
+	$( container ).on( 'click', '[data-action="add-contributor"]', function( event ) {
+		event.preventDefault();
+		_addContributors();
+	} );
+
+	// Prevent "enter" in the contributor field from submitting the whole post form.
+	$( container ).on( 'keydown', '#5ftf-pledge-contributors', function( event ) {
+		if ( 13 === event.which ) {
+			event.preventDefault();
+			_addContributors();
+		}
 	} );
 } );

--- a/plugins/wporg-5ftf/assets/js/admin.js
+++ b/plugins/wporg-5ftf/assets/js/admin.js
@@ -91,7 +91,7 @@ jQuery( document ).ready( function( $ ) {
 				const $message = $( '<div>' )
 					.attr( 'id', 'add-contrib-message' )
 					.addClass( 'notice notice-error notice-alt' )
-					.html( '<p>' + response.message + '</p>' );
+					.append( $( '<p>' ).text( response.message ) );
 
 				$( '#add-contrib-message' ).replaceWith( $message );
 			} else if ( response.contributors ) {

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -162,7 +162,7 @@ function add_pledge_contributors( $pledge_id, $contributors ) {
 	 *                            or an error code on failure.
 	 */
 	do_action( FiveForTheFuture\PREFIX . '_add_pledge_contributors', $pledge_id, $contributors, $results );
-	
+
 	return $results;
 }
 

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -252,21 +252,21 @@ function get_pledge_contributors_data( $pledge_id ) {
 	foreach ( $contributors as $contributor_status => $group ) {
 		$contrib_data[ $contributor_status ] = array_map(
 			function( $contributor_post ) use ( $contributor_status, $pledge_id ) {
-				$name = $contributor_post->post_title;
+				$name        = $contributor_post->post_title;
 				$contributor = get_user_by( 'login', $name );
 
 				return [
-					'pledgeId' => $pledge_id,
+					'pledgeId'      => $pledge_id,
 					'contributorId' => $contributor_post->ID,
-					'status'  => $contributor_status,
-					'avatar' => get_avatar( $contributor, 32 ),
+					'status'        => $contributor_status,
+					'avatar'        => get_avatar( $contributor, 32 ),
 					// @todo Add full name, from `$contributor`?
-					'name' => $name,
-					'displayName' => $contributor->display_name,
-					'publishDate' => get_the_date( '', $contributor_post ),
-					'resendLabel' => __( 'Resend Confirmation', 'wporg' ),
+					'name'          => $name,
+					'displayName'   => $contributor->display_name,
+					'publishDate'   => get_the_date( '', $contributor_post ),
+					'resendLabel'   => __( 'Resend Confirmation', 'wporg' ),
 					'removeConfirm' => sprintf( __( 'Remove %s from this pledge?', 'wporg-5ftf' ), $name ),
-					'removeLabel' => sprintf( __( 'Remove %s', 'wporg' ), $name ),
+					'removeLabel'   => sprintf( __( 'Remove %s', 'wporg' ), $name ),
 				];
 			},
 			$group

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -135,7 +135,7 @@ function populate_list_table_columns( $column, $post_id ) {
  * @param int   $pledge_id    The post ID of the pledge.
  * @param array $contributors Array of contributor wporg usernames.
  *
- * @return void
+ * @return array List of the new contributor post IDs, mapped from username => ID.
  */
 function add_pledge_contributors( $pledge_id, $contributors ) {
 	$results = array();
@@ -162,6 +162,8 @@ function add_pledge_contributors( $pledge_id, $contributors ) {
 	 *                            or an error code on failure.
 	 */
 	do_action( FiveForTheFuture\PREFIX . '_add_pledge_contributors', $pledge_id, $contributors, $results );
+	
+	return $results;
 }
 
 /**

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -239,6 +239,41 @@ function get_pledge_contributors( $pledge_id, $status = 'publish', $contributor_
 }
 
 /**
+ * Get the contributor posts in the format used for the JS templates.
+ *
+ * @param int $pledge_id The post ID of the pledge.
+ *
+ * @return array An array of contributor data, ready to be used in the JS templates.
+ */
+function get_pledge_contributors_data( $pledge_id ) {
+	$contrib_data = array();
+	$contributors = get_pledge_contributors( $pledge_id, 'all' );
+
+	foreach ( $contributors as $contributor_status => $group ) {
+		$contrib_data[ $contributor_status ] = array_map(
+			function( $contributor_post ) use ( $contributor_status, $pledge_id ) {
+				$name = $contributor_post->post_title;
+				$contributor = get_user_by( 'login', $name );
+
+				return [
+					'pledgeId' => $pledge_id,
+					'contributorId' => $contributor_post->ID,
+					'status'  => $contributor_status,
+					'avatar' => get_avatar( $contributor, 32 ),
+					// @todo Add full name, from `$contributor`?
+					'name' => $name,
+					'resendLabel' => __( 'Resend Confirmation', 'wporg' ),
+					'removeConfirm' => sprintf( __( 'Remove %s from this pledge?', 'wporg-5ftf' ), $name ),
+					'removeLabel' => sprintf( __( 'Remove %s', 'wporg' ), $name ),
+				];
+			},
+			$group
+		);
+	}
+	return $contrib_data;
+}
+
+/**
  * Get the user objects that correspond with pledge contributor posts.
  *
  * @param WP_Post[] $contributor_posts

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -262,6 +262,8 @@ function get_pledge_contributors_data( $pledge_id ) {
 					'avatar' => get_avatar( $contributor, 32 ),
 					// @todo Add full name, from `$contributor`?
 					'name' => $name,
+					'displayName' => $contributor->display_name,
+					'publishDate' => get_the_date( '', $contributor_post ),
 					'resendLabel' => __( 'Resend Confirmation', 'wporg' ),
 					'removeConfirm' => sprintf( __( 'Remove %s from this pledge?', 'wporg-5ftf' ), $name ),
 					'removeLabel' => sprintf( __( 'Remove %s', 'wporg' ), $name ),

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -15,8 +15,8 @@ add_action( 'wp_ajax_manage_contributors', __NAMESPACE__ . '\handler' );
 function handler() {
 	check_ajax_referer( 'manage-pledge', '_ajax_nonce' );
 
-	$action = filter_input( INPUT_POST, 'manage_action' );
-	$pledge_id = filter_input( INPUT_POST, 'pledge_id', FILTER_VALIDATE_INT );
+	$action         = filter_input( INPUT_POST, 'manage_action' );
+	$pledge_id      = filter_input( INPUT_POST, 'pledge_id', FILTER_VALIDATE_INT );
 	$contributor_id = filter_input( INPUT_POST, 'contributor_id', FILTER_VALIDATE_INT );
 
 	switch ( $action ) {
@@ -33,7 +33,7 @@ function handler() {
 			// Trash contributor.
 			Contributor\remove_contributor( $contributor_id );
 			wp_die( wp_json_encode( [
-				'success' => true,
+				'success'      => true,
 				'contributors' => Contributor\get_pledge_contributors_data( $pledge_id ),
 			] ) );
 			break;
@@ -52,7 +52,7 @@ function handler() {
 			$contributors = Contributor\get_pledge_contributors_data( $pledge_id );
 
 			wp_die( wp_json_encode( [
-				'success' => true,
+				'success'      => true,
 				'contributors' => $contributors,
 			] ) );
 			break;

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Handle submissions to admin-ajax.php.
+ */
+
+namespace WordPressDotOrg\FiveForTheFuture\Endpoints;
+
+use WordPressDotOrg\FiveForTheFuture\{ Contributor, PledgeForm };
+
+add_action( 'wp_ajax_manage_contributors', __NAMESPACE__ . '\handler' );
+
+/**
+ * Handle the AJAX request.
+ */
+function handler() {
+	check_ajax_referer( 'manage-pledge', '_ajax_nonce' );
+
+	$action = filter_input( INPUT_POST, 'manage_action' );
+	$pledge_id = filter_input( INPUT_POST, 'pledge_id', FILTER_VALIDATE_INT );
+	$contributor_id = filter_input( INPUT_POST, 'contributor_id', FILTER_VALIDATE_INT );
+
+	switch ( $action ) {
+		case 'resend-contributor-confirmation':
+			$contribution = get_post( $contributor_id );
+			PledgeForm\send_contributor_confirmation_emails( $pledge_id, $contributor_id );
+			wp_die( wp_json_encode( [
+				'success' => true,
+				'message' => sprintf( __( 'Confirmation email sent to %s.', 'wporg-5ftf' ), $contribution->post_title ),
+			] ) );
+			break;
+	}
+
+	// No matching action, we can just exit.
+	wp_die();
+}

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -34,6 +34,7 @@ function handler() {
 			Contributor\remove_contributor( $contributor_id );
 			wp_die( wp_json_encode( [
 				'success' => true,
+				'contributors' => Contributor\get_pledge_contributors_data( $pledge_id ),
 			] ) );
 			break;
 	}

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -7,13 +7,14 @@ namespace WordPressDotOrg\FiveForTheFuture\Endpoints;
 
 use WordPressDotOrg\FiveForTheFuture\{ Auth, Contributor, Email };
 
-add_action( 'wp_ajax_manage_contributors', __NAMESPACE__ . '\handler' );
+add_action( 'wp_ajax_manage-contributors', __NAMESPACE__ . '\manage_contributors_handler' );
 
 /**
- * Handle the AJAX request.
+ * Handle the AJAX request for managing contributors on a pledge.
+ * This responds to adding, removing, and resending emails to contributors.
  */
-function handler() {
-	check_ajax_referer( 'manage-pledge', '_ajax_nonce' );
+function manage_contributors_handler() {
+	check_ajax_referer( 'manage-contributors', '_ajax_nonce' );
 
 	$action         = filter_input( INPUT_POST, 'manage_action' );
 	$pledge_id      = filter_input( INPUT_POST, 'pledge_id', FILTER_VALIDATE_INT );
@@ -23,7 +24,7 @@ function handler() {
 
 	if ( is_wp_error( $authenticated ) ) {
 		wp_die( wp_json_encode( [
-			'success' => true,
+			'success' => false,
 			'message' => $authenticated->get_error_message(),
 		] ) );
 	}

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -37,6 +37,25 @@ function handler() {
 				'contributors' => Contributor\get_pledge_contributors_data( $pledge_id ),
 			] ) );
 			break;
+
+		case 'add-contributor':
+			$new_contributors = PledgeForm\parse_contributors( $_POST['contributors'] );
+			if ( is_wp_error( $new_contributors ) ) {
+				wp_die( wp_json_encode( [
+					'success' => false,
+					'message' => $new_contributors->get_error_message(),
+				] ) );
+			}
+			Contributor\add_pledge_contributors( $pledge_id, $new_contributors );
+
+			// Fetch all contributors, now that the new ones have been added.
+			$contributors = Contributor\get_pledge_contributors_data( $pledge_id );
+
+			wp_die( wp_json_encode( [
+				'success' => true,
+				'contributors' => $contributors,
+			] ) );
+			break;
 	}
 
 	// No matching action, we can just exit.

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -5,7 +5,7 @@
 
 namespace WordPressDotOrg\FiveForTheFuture\Endpoints;
 
-use WordPressDotOrg\FiveForTheFuture\{ Auth, Contributor, Email };
+use WordPressDotOrg\FiveForTheFuture\{ Auth, Contributor, Email, PledgeForm };
 
 add_action( 'wp_ajax_manage-contributors', __NAMESPACE__ . '\manage_contributors_handler' );
 
@@ -20,7 +20,7 @@ function manage_contributors_handler() {
 	$pledge_id      = filter_input( INPUT_POST, 'pledge_id', FILTER_VALIDATE_INT );
 	$contributor_id = filter_input( INPUT_POST, 'contributor_id', FILTER_VALIDATE_INT );
 	$token          = filter_input( INPUT_POST, '_token' );
-	$authenticated  = Auth\can_manage_pledge( $pledge_id, $auth_token );
+	$authenticated  = Auth\can_manage_pledge( $pledge_id, $token );
 
 	if ( is_wp_error( $authenticated ) ) {
 		wp_die( wp_json_encode( [

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -28,6 +28,14 @@ function handler() {
 				'message' => sprintf( __( 'Confirmation email sent to %s.', 'wporg-5ftf' ), $contribution->post_title ),
 			] ) );
 			break;
+
+		case 'remove-contributor':
+			// Trash contributor.
+			Contributor\remove_contributor( $contributor_id );
+			wp_die( wp_json_encode( [
+				'success' => true,
+			] ) );
+			break;
 	}
 
 	// No matching action, we can just exit.

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -155,7 +155,8 @@ function render_form_manage() {
 	$updated  = false;
 
 	// @todo Get pledge ID from somewhere.
-	$data = PledgeMeta\get_pledge_meta();
+	$data      = PledgeMeta\get_pledge_meta();
+	$is_manage = true;
 
 	if ( 'Update Pledge' === $action ) {
 		$processed = process_form_manage();

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -480,7 +480,18 @@ function enqueue_assets() {
 
 	$ver = filemtime( FiveForTheFuture\PATH . '/assets/js/admin.js' );
 	wp_register_script( '5ftf-admin', plugins_url( 'assets/js/admin.js', __DIR__ ), [ 'jquery' ], $ver );
-	wp_localize_script( '5ftf-admin', 'FiveForTheFuture_ManageNonce', wp_create_nonce( 'manage-pledge' ) );
+
+	$script_data = [
+		'manageNonce' => wp_create_nonce( 'manage-pledge' ),
+	];
+	wp_add_inline_script(
+		'5ftf-admin',
+		sprintf(
+			'var FiveForTheFuture = JSON.parse( decodeURIComponent( \'%s\' ) );',
+			rawurlencode( wp_json_encode( $script_data ) )
+		),
+		'before'
+	);
 
 	$current_page = get_current_screen();
 	if ( Pledge\CPT_ID === $current_page->id ) {

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -484,7 +484,7 @@ function enqueue_assets() {
 
 	$script_data = [
 		'pledgeId'    => get_the_ID(),
-		'manageNonce' => wp_create_nonce( 'manage-pledge' ),
+		'manageNonce' => wp_create_nonce( 'manage-contributors' ),
 	];
 	wp_add_inline_script(
 		'5ftf-admin',

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -210,7 +210,7 @@ function render_meta_boxes( $pledge, $box ) {
 		$data[ $key ] = get_post_meta( $pledge->ID, META_PREFIX . $key, $config['single'] );
 	}
 
-	$contributors = Contributor\get_pledge_contributors( $pledge->ID, 'all' );
+	$contributors = Contributor\get_pledge_contributors_data( $pledge->ID );
 
 	echo '<div class="pledge-form">';
 

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -483,6 +483,7 @@ function enqueue_assets() {
 	wp_register_script( '5ftf-admin', plugins_url( 'assets/js/admin.js', __DIR__ ), [ 'jquery' ], $ver );
 
 	$script_data = [
+		'pledgeId'    => get_the_ID(),
 		'manageNonce' => wp_create_nonce( 'manage-pledge' ),
 	];
 	wp_add_inline_script(

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -480,7 +480,7 @@ function enqueue_assets() {
 	wp_register_style( '5ftf-admin', plugins_url( 'assets/css/admin.css', __DIR__ ), [], $ver );
 
 	$ver = filemtime( FiveForTheFuture\PATH . '/assets/js/admin.js' );
-	wp_register_script( '5ftf-admin', plugins_url( 'assets/js/admin.js', __DIR__ ), [ 'jquery' ], $ver );
+	wp_register_script( '5ftf-admin', plugins_url( 'assets/js/admin.js', __DIR__ ), [ 'jquery', 'wp-util' ], $ver );
 
 	$script_data = [
 		'pledgeId'    => get_the_ID(),

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -279,13 +279,6 @@ function save_pledge( $pledge_id, $pledge ) {
 			get_page_by_path( 'for-organizations' )->ID
 		);
 	}
-
-	if ( filter_input( INPUT_POST, 'resend-contributor-confirmation' ) ) {
-		Email\send_contributor_confirmation_emails(
-			$pledge_id,
-			filter_input( INPUT_GET, 'resend-contributor-id', FILTER_VALIDATE_INT )
-		);
-	}
 }
 
 /**
@@ -485,8 +478,13 @@ function enqueue_assets() {
 	$ver = filemtime( FiveForTheFuture\PATH . '/assets/css/admin.css' );
 	wp_register_style( '5ftf-admin', plugins_url( 'assets/css/admin.css', __DIR__ ), [], $ver );
 
+	$ver = filemtime( FiveForTheFuture\PATH . '/assets/js/admin.js' );
+	wp_register_script( '5ftf-admin', plugins_url( 'assets/js/admin.js', __DIR__ ), [ 'jquery' ], $ver );
+	wp_localize_script( '5ftf-admin', 'FiveForTheFuture_ManageNonce', wp_create_nonce( 'manage-pledge' ) );
+
 	$current_page = get_current_screen();
 	if ( Pledge\CPT_ID === $current_page->id ) {
 		wp_enqueue_style( '5ftf-admin' );
+		wp_enqueue_script( '5ftf-admin' );
 	}
 }

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -202,7 +202,7 @@ function add_meta_boxes() {
  * @param array   $box
  */
 function render_meta_boxes( $pledge, $box ) {
-	$readonly = ! current_user_can( 'edit_page', $pledge->ID );
+	$readonly  = ! current_user_can( 'edit_page', $pledge->ID );
 	$is_manage = true;
 
 	$data = array();

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -203,6 +203,7 @@ function add_meta_boxes() {
  */
 function render_meta_boxes( $pledge, $box ) {
 	$readonly = ! current_user_can( 'edit_page', $pledge->ID );
+	$is_manage = true;
 
 	$data = array();
 	foreach ( get_pledge_meta_config() as $key => $config ) {

--- a/plugins/wporg-5ftf/index.php
+++ b/plugins/wporg-5ftf/index.php
@@ -32,6 +32,7 @@ function load() {
 	require_once get_includes_path() . 'pledge-meta.php';
 	require_once get_includes_path() . 'pledge-form.php';
 	require_once get_includes_path() . 'xprofile.php';
+	require_once get_includes_path() . 'endpoints.php';
 	require_once get_includes_path() . 'miscellaneous.php';
 
 	// The logger expects things like `$_POST` which aren't set during unit tests.

--- a/plugins/wporg-5ftf/views/inputs-pledge-contributors.php
+++ b/plugins/wporg-5ftf/views/inputs-pledge-contributors.php
@@ -2,7 +2,7 @@
 namespace WordPressDotOrg\FiveForTheFuture\View;
 
 /** @var array $data */
-/** @var bool  $readonly */
+/** @var bool  $is_manage */
 ?>
 
 <div class="form-field">
@@ -15,7 +15,7 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 		name="pledge-contributors"
 		placeholder="sanguine.zoe206, captain-mal, kayleefixesyou"
 		value="<?php echo esc_attr( $data['pledge-contributors'] ); ?>"
-		required
+		<?php echo $is_manage ? '' : 'required'; ?>
 		aria-describedby="5ftf-pledge-contributors-help"
 	/>
 	<p id="5ftf-pledge-contributors-help">

--- a/plugins/wporg-5ftf/views/inputs-pledge-org-email.php
+++ b/plugins/wporg-5ftf/views/inputs-pledge-org-email.php
@@ -31,11 +31,15 @@ use WP_Post;
 
 	<?php if ( is_admin() ) : ?>
 		<?php if ( $data['pledge-email-confirmed'] ) : ?>
-			<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
-			<?php esc_html_e( 'Confirmed', 'wporg' ); ?>
+			<p class="email-status is-confirmed">
+				<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+				<?php esc_html_e( 'Confirmed', 'wporg' ); ?>
+			</p>
 		<?php else : ?>
-			<span class="dashicons dashicons-warning" aria-hidden="true"></span>
-			<?php esc_html_e( 'Unconfirmed', 'wporg' ); ?>
+			<p class="email-status is-unconfirmed">
+				<span class="dashicons dashicons-warning" aria-hidden="true"></span>
+				<?php esc_html_e( 'Unconfirmed', 'wporg' ); ?>
+			</p>
 			<?php submit_button(
 				'Resend Confirmation',
 				'secondary',

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -1,6 +1,8 @@
 <?php
 namespace WordPressDotOrg\FiveForTheFuture\View;
 
+use function WordPressDotOrg\FiveForTheFuture\get_views_path;
+
 /** @var array $contributors */
 /** @var array $data */
 /** @var bool  $readonly */
@@ -64,9 +66,20 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 		<p><?php esc_html_e( 'There are no contributors added to this pledge yet.', 'wporg' ); ?></p>
 	<?php endif; ?>
 
-	<!-- TODO This button doesn't do anything yet.
-	<button class="button-primary" data-action="add-contributor">
+	<hr />
+
+	<?php
+	$data = [ 'pledge-contributors' => '' ];
+	require get_views_path() . 'inputs-pledge-contributors.php';
+	?>
+
+	<div id="add-contrib-message"></div>
+
+	<button
+		class="button-primary"
+		data-action="add-contributor"
+		data-pledge-post="<?php the_ID(); ?>"
+	>
 		<?php esc_html_e( 'Add new contributor', 'wporg' ); ?>
 	</button>
-	-->
 </div>

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -24,7 +24,6 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 		<button
 			class="button-link button-link-delete"
 			data-action="remove-contributor"
-			data-pledge-post="{{ data.pledgeId }}"
 			data-contributor-post="{{ data.contributorId }}"
 			data-confirm="{{ data.removeConfirm }}"
 			aria-label="{{ data.removeLabel }}"
@@ -39,7 +38,6 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 			<button
 				class="button"
 				data-action="resend-contributor-confirmation"
-				data-pledge-post="{{ data.pledgeId }}"
 				data-contributor-post="{{ data.contributorId }}"
 			>
 				{{ data.resendLabel }}
@@ -74,8 +72,7 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 	<button
 		class="button-primary"
 		data-action="add-contributor"
-		data-pledge-post="<?php the_ID(); ?>"
 	>
-		<?php esc_html_e( 'Add new contributor', 'wporg' ); ?>
+		<?php esc_html_e( 'Add new contributors', 'wporg' ); ?>
 	</button>
 </div>

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -6,7 +6,7 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 /** @var bool  $readonly */
 ?>
 
-<div class="5ftf-contributors">
+<div id="5ftf-contributors">
 	<?php if ( ! empty( $contributors ) ) : ?>
 		<?php foreach ( $contributors as $contributor_status => $group ) : ?>
 			<?php if ( ! empty( $group ) ) : ?>

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -8,63 +8,59 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 /** @var bool  $readonly */
 ?>
 
-<div id="5ftf-contributors">
-	<?php if ( ! empty( $contributors ) ) : ?>
-		<?php foreach ( $contributors as $contributor_status => $group ) : ?>
-			<?php if ( ! empty( $group ) ) : ?>
-				<h3 class="contributor-list-heading">
-					<?php
-					switch ( $contributor_status ) {
-						case 'pending':
-							esc_html_e( 'Unconfirmed', 'wporg' );
-							break;
-						case 'publish':
-							esc_html_e( 'Confirmed', 'wporg' );
-							break;
-					}
-					?>
-				</h3>
+<script type="text/template" id="tmpl-5ftf-contributor-lists">
+	<# if ( data.publish.length ) { #>
+		<h3 class="contributor-list-heading"><?php esc_html_e( 'Confirmed', 'wporg' ); ?></h3>
+		<ul class="contributor-list publish">{{{ data.publish }}}</ul>
+	<# } #>
+	<# if ( data.pending.length ) { #>
+		<h3 class="contributor-list-heading"><?php esc_html_e( 'Unconfirmed', 'wporg' ); ?></h3>
+		<ul class="contributor-list pending">{{{ data.pending }}}</ul>
+	<# } #>
+</script>
 
-				<ul class="contributor-list <?php echo esc_attr( $contributor_status ); ?>">
-					<?php foreach ( $group as $contributor_post ) :
-						$name = $contributor_post->post_title;
-						$contributor = get_user_by( 'login', $name );
-						$remove_confirm = sprintf( __( 'Remove %s from this pledge?', 'wporg-5ftf' ), $name );
-						$remove_label = sprintf( __( 'Remove %s', 'wporg' ), $name );
-						?>
-						<li>
-							<button
-								class="button-link button-link-delete"
-								data-action="remove-contributor"
-								data-pledge-post="<?php the_ID(); ?>"
-								data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>"
-								data-confirm="<?php echo esc_attr( $remove_confirm ); ?>"
-								aria-label="<?php echo esc_attr( $remove_label ); ?>"
-							>
-								<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
-							</button>
-							<?php echo get_avatar( $contributor->user_email, 32 ); ?>
-							<span class="contributor-list__name">
-								<?php echo esc_html( $name ); ?>
-							</span>
-							<?php if ( 'pending' === $contributor_post->post_status ) : ?>
-								<button
-									class="button"
-									data-action="resend-contributor-confirmation"
-									data-pledge-post="<?php the_ID(); ?>"
-									data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>"
-								>
-									<?php esc_html_e( 'Resend Confirmation', 'wporg' ); ?>
-								</button>
-							<?php endif; ?>
-						</li>
-					<?php endforeach; ?>
-				</ul>
-			<?php endif; ?>
-		<?php endforeach; ?>
-	<?php else : ?>
-		<p><?php esc_html_e( 'There are no contributors added to this pledge yet.', 'wporg' ); ?></p>
-	<?php endif; ?>
+<script type="text/template" id="tmpl-5ftf-contributor">
+	<li>
+		<button
+			class="button-link button-link-delete"
+			data-action="remove-contributor"
+			data-pledge-post="{{ data.pledgeId }}"
+			data-contributor-post="{{ data.contributorId }}"
+			data-confirm="{{ data.removeConfirm }}"
+			aria-label="{{ data.removeLabel }}"
+		>
+			<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
+		</button>
+		{{{ data.avatar }}}
+		<span class="contributor-list__name">
+			{{ data.name }}
+		</span>
+		<# if ( 'pending' === data.status ) { #>
+			<button
+				class="button"
+				data-action="resend-contributor-confirmation"
+				data-pledge-post="{{ data.pledgeId }}"
+				data-contributor-post="{{ data.contributorId }}"
+			>
+				{{ data.resendLabel }}
+			</button>
+		<# } #>
+	</li>
+</script> 
+
+<div id="5ftf-contributors">
+	<div class="pledge-contributors">
+		<?php if ( ! empty( $contributors ) ) : ?>
+			<?php
+			printf(
+				'<script>var fftfContributors = JSON.parse( decodeURIComponent( \'%s\' ) );</script>',
+				rawurlencode( wp_json_encode( $contributors ) )
+			);
+			?>
+		<?php else : ?>
+			<p><?php esc_html_e( 'There are no contributors added to this pledge yet.', 'wporg' ); ?></p>
+		<?php endif; ?>
+	</div>
 
 	<hr />
 

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -33,6 +33,9 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 			<tbody>{{{ data.pending }}}</tbody>
 		</table>
 	<# } #>
+	<# if ( ! data.publish.length && ! data.pending.length ) { #>
+		<p><?php esc_html_e( 'There are no contributors added to this pledge yet.', 'wporg-5ftf' ); ?></p>
+	<# } #>
 </script>
 
 <script type="text/template" id="tmpl-5ftf-contributor">

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -26,7 +26,7 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 			<thead>
 				<tr>
 					<th scope="col"><?php esc_html_e( 'Contributor', 'wporg-5ftf' ); ?></th>
-					<th scope="col"><?php esc_html_e( 'Resend Confirmation', 'wporg-5ftf' ); ?></th>
+					<th scope="col" class="resend-confirm"><?php esc_html_e( 'Resend Confirmation', 'wporg-5ftf' ); ?></th>
 					<th scope="col"><?php esc_html_e( 'Remove Contributor', 'wporg-5ftf' ); ?></th>
 				</tr>
 			</thead>
@@ -47,7 +47,7 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 			</span>
 		</th>
 		<# if ( 'pending' === data.status ) { #>
-			<td>
+			<td class="resend-confirm">
 				<button
 					class="button"
 					data-action="resend-contributor-confirmation"
@@ -75,7 +75,7 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 </script> 
 
 <div id="5ftf-contributors">
-	<div class="pledge-contributors">
+	<div class="pledge-contributors pledge-status__<?php echo esc_attr( get_post_status() ); ?>">
 		<?php if ( ! empty( $contributors ) ) : ?>
 			<?php
 			printf(

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -93,7 +93,7 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 	require get_views_path() . 'inputs-pledge-contributors.php';
 	?>
 
-	<div id="add-contrib-message"></div>
+	<div id="add-contrib-message" role="alert" aria-atomic="true"></div>
 
 	<button
 		class="button-primary"

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -28,21 +28,17 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 						$contributor = get_user_by( 'login', $contributor_post->post_title );
 						?>
 						<li>
-							<?php echo get_avatar( $contributor->user_email, 32 ); ?>
-							<?php echo esc_html( $contributor_post->post_title ); ?>
-							<!-- TODO These buttons don't do anything yet.
-							<button class="button-primary" data-action="remove-contributor" data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>">
-								<?php esc_html_e( 'Remove', 'wporg' ); ?>
+							<button class="button-link button-link-delete" data-action="remove-contributor" data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>" aria-label="<?php esc_html_e( 'Remove', 'wporg' ); ?>">
+								<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
 							</button>
-							-->
+							<?php echo get_avatar( $contributor->user_email, 32 ); ?>
+							<span class="contributor-list__name">
+								<?php echo esc_html( $contributor_post->post_title ); ?>
+							</span>
 							<?php if ( 'pending' === $contributor_post->post_status ) : ?>
-								<?php submit_button(
-									'Resend Confirmation',
-									'secondary',
-									'resend-contributor-confirmation',
-									false,
-									array( 'formaction' => add_query_arg( 'resend-contributor-id', $contributor_post->ID ) )
-								); ?>
+								<button class="button" data-action="resend-contributor-confirmation" data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>">
+									<?php esc_html_e( 'Resend Confirmation', 'wporg' ); ?>
+								</button>
 							<?php endif; ?>
 						</li>
 					<?php endforeach; ?>

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -25,18 +25,33 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 
 				<ul class="contributor-list <?php echo esc_attr( $contributor_status ); ?>">
 					<?php foreach ( $group as $contributor_post ) :
-						$contributor = get_user_by( 'login', $contributor_post->post_title );
+						$name = $contributor_post->post_title;
+						$contributor = get_user_by( 'login', $name );
+						$remove_confirm = sprintf( __( 'Remove %s from this pledge?', 'wporg-5ftf' ), $name );
+						$remove_label = sprintf( __( 'Remove %s', 'wporg' ), $name );
 						?>
 						<li>
-							<button class="button-link button-link-delete" data-action="remove-contributor" data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>" aria-label="<?php esc_html_e( 'Remove', 'wporg' ); ?>">
+							<button
+								class="button-link button-link-delete"
+								data-action="remove-contributor"
+								data-pledge-post="<?php the_ID(); ?>"
+								data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>"
+								data-confirm="<?php echo esc_attr( $remove_confirm ); ?>"
+								aria-label="<?php echo esc_attr( $remove_label ); ?>"
+							>
 								<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
 							</button>
 							<?php echo get_avatar( $contributor->user_email, 32 ); ?>
 							<span class="contributor-list__name">
-								<?php echo esc_html( $contributor_post->post_title ); ?>
+								<?php echo esc_html( $name ); ?>
 							</span>
 							<?php if ( 'pending' === $contributor_post->post_status ) : ?>
-								<button class="button" data-action="resend-contributor-confirmation" data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>">
+								<button
+									class="button"
+									data-action="resend-contributor-confirmation"
+									data-pledge-post="<?php the_ID(); ?>"
+									data-contributor-post="<?php echo esc_attr( $contributor_post->ID ); ?>"
+								>
 									<?php esc_html_e( 'Resend Confirmation', 'wporg' ); ?>
 								</button>
 							<?php endif; ?>

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -11,39 +11,64 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 <script type="text/template" id="tmpl-5ftf-contributor-lists">
 	<# if ( data.publish.length ) { #>
 		<h3 class="contributor-list-heading"><?php esc_html_e( 'Confirmed', 'wporg' ); ?></h3>
-		<ul class="contributor-list publish">{{{ data.publish }}}</ul>
+		<table class="contributor-list publish striped widefat">
+			<thead>
+				<th scope="col"><?php esc_html_e( 'Contributor', 'wporg-5ftf' ); ?></th>
+				<th scope="col"><?php esc_html_e( 'Date Confirmed', 'wporg-5ftf' ); ?></th>
+				<th scope="col"><?php esc_html_e( 'Remove Contributor', 'wporg-5ftf' ); ?></th>
+			</thead>
+			<tbody>{{{ data.publish }}}</tbody>
+		</table>
 	<# } #>
 	<# if ( data.pending.length ) { #>
 		<h3 class="contributor-list-heading"><?php esc_html_e( 'Unconfirmed', 'wporg' ); ?></h3>
-		<ul class="contributor-list pending">{{{ data.pending }}}</ul>
+		<table class="contributor-list pending striped widefat">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Contributor', 'wporg-5ftf' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Resend Confirmation', 'wporg-5ftf' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Remove Contributor', 'wporg-5ftf' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>{{{ data.pending }}}</tbody>
+		</table>
 	<# } #>
 </script>
 
 <script type="text/template" id="tmpl-5ftf-contributor">
-	<li>
-		<button
-			class="button-link button-link-delete"
-			data-action="remove-contributor"
-			data-contributor-post="{{ data.contributorId }}"
-			data-confirm="{{ data.removeConfirm }}"
-			aria-label="{{ data.removeLabel }}"
-		>
-			<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
-		</button>
-		{{{ data.avatar }}}
-		<span class="contributor-list__name">
-			{{ data.name }}
-		</span>
+	<tr>
+		<th scope="row">
+			{{{ data.avatar }}}
+			<span class="contributor-list__name">
+				{{ data.displayName }} ({{ data.name }})
+			</span>
+		</th>
 		<# if ( 'pending' === data.status ) { #>
-			<button
-				class="button"
-				data-action="resend-contributor-confirmation"
-				data-contributor-post="{{ data.contributorId }}"
-			>
-				{{ data.resendLabel }}
-			</button>
+			<td>
+				<button
+					class="button"
+					data-action="resend-contributor-confirmation"
+					data-contributor-post="{{ data.contributorId }}"
+				>
+					{{ data.resendLabel }}
+				</button>
+			</td>
+		<# } else { #>
+			<td>{{ data.publishDate }}</td>
 		<# } #>
-	</li>
+		<td>
+			<button
+				class="button-link button-link-delete"
+				data-action="remove-contributor"
+				data-contributor-post="{{ data.contributorId }}"
+				data-confirm="{{ data.removeConfirm }}"
+				aria-label="{{ data.removeLabel }}"
+			>
+				<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
+				<?php esc_html_e( 'Remove', 'wporg-5ftf' ); ?>
+			</button>
+		</td>
+	</tr>
 </script> 
 
 <div id="5ftf-contributors">
@@ -59,8 +84,6 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 			<p><?php esc_html_e( 'There are no contributors added to this pledge yet.', 'wporg' ); ?></p>
 		<?php endif; ?>
 	</div>
-
-	<hr />
 
 	<?php
 	$data = [ 'pledge-contributors' => '' ];


### PR DESCRIPTION
This updates the display of contributors into a table view, and adds the ability to add and remove contributors to existing pledges.

The display has been refactored to use JS templates & JSON contributor data– the data is output onto the page when loaded from the server, and rendered when the page finishes loading. Adding & removing contributors now submits to an admin-ajax.php endpoint, which, if successful, return the new list of contributors. This ensures the display is always up to date. 

Fixes #3.

<img width="483" alt="Screen Shot 2019-11-13 at 4 54 19 PM" src="https://user-images.githubusercontent.com/541093/68807714-50186c80-0636-11ea-8bfe-380b5ae82c45.png">

**To test**

- Edit a pledge in wp-admin
- View the contributors, they should be in the correct "confirmed"/"unconfirmed" table
- Resend a confirmation email, it should be sent & you'll get a success alert.
- Remove a contributor, you will have to confirm that you intend to do this.
- Hit cancel, it should not remove the contributor.
- Remove a contributor, hit OK this time
- The list should refresh and that contributor should be gone now
- Add some users to the new contributors text input
- Submit either by hitting enter in the input, or clicking the buttton
- It should succeed, and show those contribs in the unconfirmed list now
- Invalid users should trigger an error message & not add anyone

cc @melchoyce to check design :)