### PR TITLE
Pledges: Add manage form for pledge admins

### DIFF
--- a/plugins/wporg-5ftf/assets/js/admin.js
+++ b/plugins/wporg-5ftf/assets/js/admin.js
@@ -1,6 +1,12 @@
 /* global ajaxurl, FiveForTheFuture, fftfContributors, jQuery */
 /* eslint no-alert: "off" */
 jQuery( document ).ready( function( $ ) {
+	let ajaxurl = window.ajaxurl;
+	// Set the ajax url if the global is undefined.
+	if ( 'undefined' === typeof ajaxurl ) {
+		ajaxurl = FiveForTheFuture.ajaxurl;
+	}
+
 	/**
 	 * Render the contributor lists using the contributors template into the pledge-contributors container. This
 	 * uses `_renderContributors` to render a list of contributors per status (published, pending).
@@ -68,6 +74,7 @@ jQuery( document ).ready( function( $ ) {
 				action: 'manage-contributors',
 				pledge_id: FiveForTheFuture.pledgeId,
 				_ajax_nonce: FiveForTheFuture.manageNonce,
+				_token: FiveForTheFuture.authToken,
 			}, data ),
 			success: callback,
 			dataType: 'json',
@@ -83,17 +90,19 @@ jQuery( document ).ready( function( $ ) {
 			return;
 		}
 
+		// Clear the error message field.
+		$( '#add-contrib-message' ).html( '' );
+
 		sendAjaxRequest( {
 			contributors: contribs,
 			manage_action: 'add-contributor',
 		}, function( response ) {
 			if ( ! response.success ) {
 				const $message = $( '<div>' )
-					.attr( 'id', 'add-contrib-message' )
 					.addClass( 'notice notice-error notice-alt' )
 					.append( $( '<p>' ).text( response.message ) );
 
-				$( '#add-contrib-message' ).replaceWith( $message );
+				$( '#add-contrib-message' ).html( $message );
 			} else if ( response.contributors ) {
 				render( response.contributors, container );
 				$( '#5ftf-pledge-contributors' ).val( '' );

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -248,6 +248,9 @@ function get_pledge_contributors( $pledge_id, $status = 'publish', $contributor_
  * @return array An array of contributor data, ready to be used in the JS templates.
  */
 function get_pledge_contributors_data( $pledge_id ) {
+	if ( ! $pledge_id ) {
+		return array();
+	}
 	$contrib_data = array();
 	$contributors = get_pledge_contributors( $pledge_id, 'all' );
 

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -8,7 +8,8 @@ namespace WordPressDotOrg\FiveForTheFuture\Endpoints;
 use WordPressDotOrg\FiveForTheFuture\{ Auth, Contributor, Email };
 use const WordPressDotOrg\FiveForTheFuture\PledgeMeta\META_PREFIX;
 
-add_action( 'wp_ajax_manage-contributors', __NAMESPACE__ . '\manage_contributors_handler' );
+add_action( 'wp_ajax_manage-contributors',        __NAMESPACE__ . '\manage_contributors_handler' );
+add_action( 'wp_ajax_nopriv_manage-contributors', __NAMESPACE__ . '\manage_contributors_handler' );
 
 add_action( 'wp_ajax_send-manage-email',        __NAMESPACE__ . '\send_manage_email_handler' );
 add_action( 'wp_ajax_nopriv_send-manage-email', __NAMESPACE__ . '\send_manage_email_handler' );
@@ -29,7 +30,7 @@ function manage_contributors_handler() {
 	if ( is_wp_error( $authenticated ) ) {
 		wp_die( wp_json_encode( [
 			'success' => false,
-			'message' => $authenticated->get_error_message(),
+			'message' => __( 'Sorry, you don\'t have permissions to do that.', 'wporg-5ftf' ),
 		] ) );
 	}
 

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -5,7 +5,7 @@
 
 namespace WordPressDotOrg\FiveForTheFuture\Endpoints;
 
-use WordPressDotOrg\FiveForTheFuture\{ Auth, Contributor, Email, PledgeForm };
+use WordPressDotOrg\FiveForTheFuture\{ Auth, Contributor, Email };
 use const WordPressDotOrg\FiveForTheFuture\PledgeMeta\META_PREFIX;
 
 add_action( 'wp_ajax_manage-contributors', __NAMESPACE__ . '\manage_contributors_handler' );
@@ -54,7 +54,7 @@ function manage_contributors_handler() {
 
 		case 'add-contributor':
 			$pledge = get_post( $pledge_id );
-			$new_contributors = PledgeForm\parse_contributors( $_POST['contributors'] );
+			$new_contributors = Contributor\parse_contributors( $_POST['contributors'] );
 			if ( is_wp_error( $new_contributors ) ) {
 				wp_die( wp_json_encode( [
 					'success' => false,

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -220,49 +220,6 @@ function get_form_submission() {
 }
 
 /**
- * Check a key value against existing pledges to see if one already exists.
- *
- * @param string $key               The value to match against other pledges.
- * @param string $key_type          The type of value being matched. `email` or `domain`.
- * @param int    $current_pledge_id Optional. The post ID of the pledge to compare against others.
- *
- * @return bool
- */
-function has_existing_pledge( $key, $key_type, int $current_pledge_id = 0 ) {
-	$args = array(
-		'post_type'   => Pledge\CPT_ID,
-		'post_status' => array( 'draft', 'pending', 'publish' ),
-	);
-
-	switch ( $key_type ) {
-		case 'email':
-			$args['meta_query'] = array(
-				array(
-					'key'   => PledgeMeta\META_PREFIX . 'org-pledge-email',
-					'value' => $key,
-				),
-			);
-			break;
-		case 'domain':
-			$args['meta_query'] = array(
-				array(
-					'key'   => PledgeMeta\META_PREFIX . 'org-domain',
-					'value' => $key,
-				),
-			);
-			break;
-	}
-
-	if ( $current_pledge_id ) {
-		$args['exclude'] = array( $current_pledge_id );
-	}
-
-	$matching_pledge = get_posts( $args );
-
-	return ! empty( $matching_pledge );
-}
-
-/**
  * Ensure each item in a list of usernames is valid and corresponds to a user.
  *
  * @param string $contributors A comma-separated list of username strings.
@@ -335,7 +292,7 @@ function check_invalid_submission( $submission ) {
 		Pledge\CPT_ID
 	);
 
-	if ( has_existing_pledge( $email, 'email' ) ) {
+	if ( Pledge\has_existing_pledge( $email, 'email' ) ) {
 		return new WP_Error(
 			'existing_pledge_email',
 			__( 'This email address is already connected to an existing pledge.', 'wporg-5ftf' )
@@ -344,7 +301,7 @@ function check_invalid_submission( $submission ) {
 
 	$domain = PledgeMeta\get_normalized_domain_from_url( $submission['org-url'] );
 
-	if ( has_existing_pledge( $domain, 'domain' ) ) {
+	if ( Pledge\has_existing_pledge( $domain, 'domain' ) ) {
 		return new WP_Error(
 			'existing_pledge_domain',
 			__( 'A pledge already exists for this domain.', 'wporg-5ftf' )

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -175,8 +175,6 @@ function render_form_manage() {
 		return ob_get_clean();
 	}
 
-	$contributors = Contributor\get_pledge_contributors( $pledge_id, $status = 'all' );
-
 	if ( 'Update Pledge' === $action ) {
 		$results = process_form_manage( $pledge_id, $auth_token );
 
@@ -187,7 +185,8 @@ function render_form_manage() {
 		}
 	}
 
-	$data = PledgeMeta\get_pledge_meta( $pledge_id );
+	$data         = PledgeMeta\get_pledge_meta( $pledge_id );
+	$contributors = Contributor\get_pledge_contributors_data( $pledge_id );
 
 	ob_start();
 	$readonly = false;
@@ -214,7 +213,7 @@ function process_form_manage( $pledge_id, $auth_token ) {
 	 */
 	$can_view_form = Auth\can_manage_pledge( $pledge_id, $auth_token );
 
-	if ( ! $has_valid_nonce || ! $can_view_form ) {
+	if ( ! $has_valid_nonce || is_wp_error( $can_view_form ) ) {
 		return new WP_Error(
 			'invalid_token',
 			sprintf(

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -232,7 +232,29 @@ function process_form_manage( $pledge_id, $auth_token ) {
 
 	PledgeMeta\save_pledge_meta( $pledge_id, $submission );
 
-	// @todo Upload & attach logo.
+	if ( isset( $_FILES['org-logo'], $_FILES['org-logo']['tmp_name'] ) && ! empty( $_FILES['org-logo']['tmp_name'] ) ) {
+		$original_logo_id   = get_post_thumbnail_id( $pledge_id );
+		$logo_attachment_id = upload_image( $_FILES['org-logo'] );
+		if ( is_wp_error( $logo_attachment_id ) ) {
+			return $logo_attachment_id;
+		}
+
+		// Attach new logo to the pledge.
+		wp_update_post( array(
+			'ID'          => $logo_attachment_id,
+			'post_parent' => $pledge_id,
+		) );
+		$updated = set_post_thumbnail( $pledge_id, $logo_attachment_id );
+
+		// Trash the old logo.
+		if ( $updated ) {
+			$orig_logo_attachment = get_post( $original_logo_id );
+			if ( $orig_logo_attachment && $pledge_id === $orig_logo_attachment->post_parent ) {
+				wp_delete_attachment( $original_logo_id );
+			}
+		}
+	}
+
 	// @todo Save contributors.
 
 	// If we made it to here, we've successfully saved the pledge.

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -70,7 +70,7 @@ function process_form_new() {
 		return $has_error;
 	}
 
-	$contributors = parse_contributors( $submission['pledge-contributors'] );
+	$contributors = Contributor\parse_contributors( $submission['pledge-contributors'] );
 	if ( is_wp_error( $contributors ) ) {
 		return $contributors;
 	}
@@ -217,61 +217,6 @@ function get_form_submission() {
 	}
 
 	return $result;
-}
-
-/**
- * Ensure each item in a list of usernames is valid and corresponds to a user.
- *
- * @param string $contributors A comma-separated list of username strings.
- *
- * @return array|WP_Error An array of sanitized wporg usernames on success. Otherwise WP_Error.
- */
-function parse_contributors( $contributors ) {
-	$invalid_contributors   = array();
-	$sanitized_contributors = array();
-
-	$contributors = str_replace( '@', '', $contributors );
-	$contributors = explode( ',', $contributors );
-
-	foreach ( $contributors as $wporg_username ) {
-		$sanitized_username = sanitize_user( $wporg_username );
-		$user               = get_user_by( 'login', $sanitized_username );
-
-		if ( ! $user instanceof WP_User ) {
-			$user = get_user_by( 'slug', $sanitized_username );
-		}
-
-		if ( $user instanceof WP_User ) {
-			$sanitized_contributors[] = $user->user_login;
-		} else {
-			$invalid_contributors[] = $wporg_username;
-		}
-	}
-
-	if ( ! empty( $invalid_contributors ) ) {
-		/* translators: Used between sponsor names in a list, there is a space after the comma. */
-		$item_separator = _x( ', ', 'list item separator', 'wporg-5ftf' );
-
-		return new WP_Error(
-			'invalid_contributor',
-			sprintf(
-				/* translators: %s is a list of usernames. */
-				__( 'The following contributor usernames are not valid: %s', 'wporg-5ftf' ),
-				implode( $item_separator, $invalid_contributors )
-			)
-		);
-	}
-
-	if ( empty( $sanitized_contributors ) ) {
-		return new WP_Error(
-			'contributor_required',
-			__( 'The pledge must have at least one contributor username.', 'wporg-5ftf' )
-		);
-	}
-
-	$sanitized_contributors = array_unique( $sanitized_contributors );
-
-	return $sanitized_contributors;
 }
 
 /**

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -28,34 +28,38 @@ add_action( 'added_post_meta',  __NAMESPACE__ . '\update_generated_meta', 10, 4 
 /**
  * Define pledge meta fields and their properties.
  *
- * @param string $context Optional. The part of the config to return. 'user_input', 'generated', or 'all'.
+ * @param string $subset Optional. The part of the config to return: 'user_input', 'generated', or 'all'.
  *
  * @return array
  */
-function get_pledge_meta_config( $context = 'all' ) {
+function get_pledge_meta_config( $subset = 'all' ) {
 	$user_input = array(
 		'org-description'  => array(
 			'single'            => true,
 			'sanitize_callback' => __NAMESPACE__ . '\sanitize_description',
 			'show_in_rest'      => true,
+			'context'           => array( 'create', 'update' ),
 			'php_filter'        => FILTER_UNSAFE_RAW,
 		),
 		'org-name'         => array(
 			'single'            => true,
 			'sanitize_callback' => 'sanitize_text_field',
 			'show_in_rest'      => true,
+			'context'           => array( 'create', 'update' ),
 			'php_filter'        => FILTER_SANITIZE_STRING,
 		),
 		'org-url'          => array(
 			'single'            => true,
 			'sanitize_callback' => 'esc_url_raw',
 			'show_in_rest'      => true,
+			'context'           => array( 'create', 'update' ),
 			'php_filter'        => FILTER_VALIDATE_URL,
 		),
 		'org-pledge-email' => array(
 			'single'            => true,
 			'sanitize_callback' => 'sanitize_email',
 			'show_in_rest'      => false,
+			'context'           => array( 'create' ),
 			'php_filter'        => FILTER_VALIDATE_EMAIL,
 		),
 	);
@@ -83,7 +87,7 @@ function get_pledge_meta_config( $context = 'all' ) {
 		),
 	);
 
-	switch ( $context ) {
+	switch ( $subset ) {
 		case 'user_input':
 			$return = $user_input;
 			break;
@@ -107,7 +111,6 @@ function get_pledge_meta_config( $context = 'all' ) {
  */
 function sanitize_description( $insecure ) {
 	$secure = wp_kses_data( $insecure );
-	$secure = wpautop( $secure );
 	$secure = wp_unslash( wp_rel_nofollow( $secure ) );
 
 	return $secure;
@@ -243,12 +246,13 @@ function save_pledge( $pledge_id, $pledge ) {
 	$get_action      = filter_input( INPUT_GET, 'action' );
 	$post_action     = filter_input( INPUT_POST, 'action' );
 	$ignored_actions = array( 'trash', 'untrash', 'restore' );
+	$context         = ( 'editpost' === $post_action ) ? 'update' : 'create';
 
 	/*
 	 * This is only intended to run when the front end form and wp-admin forms are submitted, not when posts are
 	 * programmatically updated.
 	 */
-	if ( 'Submit Pledge' !== $post_action && 'editpost' !== $post_action ) {
+	if ( ! in_array( $post_action, [ 'Submit Pledge', 'editpost' ], true ) ) {
 		return;
 	}
 
@@ -268,7 +272,7 @@ function save_pledge( $pledge_id, $pledge ) {
 
 	$submitted_meta = PledgeForm\get_form_submission();
 
-	if ( is_wp_error( has_required_pledge_meta( $submitted_meta ) ) ) {
+	if ( is_wp_error( has_required_pledge_meta( $submitted_meta, $context ) ) ) {
 		return;
 	}
 
@@ -294,6 +298,10 @@ function save_pledge_meta( $pledge_id, $new_values ) {
 	$config = get_pledge_meta_config();
 
 	foreach ( $new_values as $key => $value ) {
+		// A null value can happen if the submission form did not have a given field.
+		if ( is_null( $value ) ) {
+			continue;
+		}
 		if ( array_key_exists( $key, $config ) ) {
 			$meta_key = META_PREFIX . $key;
 
@@ -391,14 +399,22 @@ function update_single_cached_pledge_data( $pledge_id ) {
 /**
  * Check that an array contains values for all required keys.
  *
- * @return bool|WP_Error True if all required values are present. Otherwise WP_Error.
+ * @param array  $submission Form submission data.
+ * @param string $context    Whether this is a new pledge (`create`) or an edit to an existing one (`update`).
+ *
+ * @return true|WP_Error True if all required values are present. Otherwise WP_Error.
  */
-function has_required_pledge_meta( array $submission ) {
+function has_required_pledge_meta( array $submission, $context ) {
 	$error = new WP_Error();
 
-	$required = array_keys( get_pledge_meta_config( 'user_input' ) );
+	$meta_config = get_pledge_meta_config( 'user_input' );
+	$required    = array_keys( $meta_config );
 
 	foreach ( $required as $key ) {
+		if ( ! in_array( $context, $meta_config[ $key ]['context'] ) ) {
+			continue;
+		}
+
 		if ( ! isset( $submission[ $key ] ) || is_null( $submission[ $key ] ) ) {
 			$error->add(
 				'required_field_empty',
@@ -428,19 +444,23 @@ function has_required_pledge_meta( array $submission ) {
 /**
  * Get the metadata for a given pledge, or a default set if no pledge is provided.
  *
- * @param int    $pledge_id
- * @param string $context
+ * @param int    $pledge_id Pledge to fetch data from.
+ * @param string $subset    Optional. The part of the config to return: 'user_input', 'generated', or 'all'.
+ *
  * @return array Pledge data
  */
-function get_pledge_meta( $pledge_id = 0, $context = '' ) {
+function get_pledge_meta( $pledge_id = 0, $subset = '' ) {
 	// Get existing pledge, if it exists.
 	$pledge = get_post( $pledge_id );
 
-	$keys = get_pledge_meta_config( $context );
+	$keys = get_pledge_meta_config( $subset );
 	$meta = array();
 
 	// Get POST'd submission, if it exists.
 	$submission = PledgeForm\get_form_submission();
+	if ( isset( $submission['empty_post'] ) && $submission['empty_post'] ) {
+		$submission = array();
+	}
 
 	foreach ( $keys as $key => $config ) {
 		if ( isset( $submission[ $key ] ) ) {

--- a/plugins/wporg-5ftf/includes/pledge.php
+++ b/plugins/wporg-5ftf/includes/pledge.php
@@ -261,6 +261,49 @@ function filter_query( $query ) {
 }
 
 /**
+ * Check a key value against existing pledges to see if one already exists.
+ *
+ * @param string $key               The value to match against other pledges.
+ * @param string $key_type          The type of value being matched. `email` or `domain`.
+ * @param int    $current_pledge_id Optional. The post ID of the pledge to compare against others.
+ *
+ * @return bool
+ */
+function has_existing_pledge( $key, $key_type, int $current_pledge_id = 0 ) {
+	$args = array(
+		'post_type'   => CPT_ID,
+		'post_status' => array( 'draft', 'pending', 'publish' ),
+	);
+
+	switch ( $key_type ) {
+		case 'email':
+			$args['meta_query'] = array(
+				array(
+					'key'   => META_PREFIX . 'org-pledge-email',
+					'value' => $key,
+				),
+			);
+			break;
+		case 'domain':
+			$args['meta_query'] = array(
+				array(
+					'key'   => META_PREFIX . 'org-domain',
+					'value' => $key,
+				),
+			);
+			break;
+	}
+
+	if ( $current_pledge_id ) {
+		$args['exclude'] = array( $current_pledge_id );
+	}
+
+	$matching_pledge = get_posts( $args );
+
+	return ! empty( $matching_pledge );
+}
+
+/**
  * Enqueue assets for front-end management.
  *
  * @return void

--- a/plugins/wporg-5ftf/views/form-pledge-manage.php
+++ b/plugins/wporg-5ftf/views/form-pledge-manage.php
@@ -33,6 +33,11 @@ require __DIR__ . '/partial-result-messages.php';
 				value="<?php esc_attr_e( 'Update Pledge', 'wporg-5ftf' ); ?>"
 			/>
 		</div>
+
+		<h2><?php esc_html_e( 'Contributors', 'wporg-5ftf' ); ?></h2>
+
+		<?php require get_views_path() . 'manage-contributors.php'; ?>
+
 	</form>
 
 <?php endif; ?>

--- a/plugins/wporg-5ftf/views/form-pledge-manage.php
+++ b/plugins/wporg-5ftf/views/form-pledge-manage.php
@@ -1,25 +1,38 @@
 <?php
-namespace WordPressDotOrg\FiveForTheFuture\View;
 
+namespace WordPressDotOrg\FiveForTheFuture\View;
 use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 
-/** @var array $messages */
-/** @var bool  $updated */
+/**
+ * @var bool   $can_view_form
+ * @var int    $pledge_id
+ * @var string $auth_token
+ */
+
+require __DIR__ . '/partial-result-messages.php';
+
 ?>
 
-<form class="pledge-form" id="5ftf-form-pledge-manage" action="" method="post" enctype="multipart/form-data">
-	<?php
-	require get_views_path() . 'inputs-pledge-org-info.php';
-	require get_views_path() . 'manage-contributors.php';
-	require get_views_path() . 'inputs-pledge-org-email.php';
-	?>
+<?php if ( true === $can_view_form ) : ?>
 
-	<div>
-		<input
-			type="submit"
-			id="5ftf-pledge-submit"
-			name="action"
-			value="<?php esc_attr_e( 'Update Pledge', 'wporg-5ftf' ); ?>"
-		/>
-	</div>
-</form>
+	<form class="pledge-form" id="5ftf-form-pledge-manage" action="" method="post" enctype="multipart/form-data">
+		<input type="hidden" name="pledge_id" value="<?php echo absint( $pledge_id ); ?>" />
+		<input type="hidden" name="auth_token" value="<?php echo esc_attr( $auth_token ); ?>" />
+
+		<?php
+		wp_nonce_field( 'manage_pledge_' . $pledge_id );
+
+		require get_views_path() . 'inputs-pledge-org-info.php';
+		?>
+
+		<div>
+			<input
+				type="submit"
+				id="5ftf-pledge-submit"
+				name="action"
+				value="<?php esc_attr_e( 'Update Pledge', 'wporg-5ftf' ); ?>"
+			/>
+		</div>
+	</form>
+
+<?php endif; ?>

--- a/plugins/wporg-5ftf/views/inputs-pledge-org-info.php
+++ b/plugins/wporg-5ftf/views/inputs-pledge-org-info.php
@@ -1,8 +1,13 @@
 <?php
+
 namespace WordPressDotOrg\FiveForTheFuture\View;
 
-/** @var array $data */
-/** @var bool  $readonly */
+/**
+ * @var array  $data
+ * @var int    $pledge_id
+ * @var bool   $readonly
+ */
+
 ?>
 
 <div class="form-field">
@@ -20,6 +25,11 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 </div>
 
 <?php if ( ! is_admin() ) : ?>
+	<?php if ( has_post_thumbnail( $pledge_id ) ) : ?>
+		<div class="form-field form-field__logo-display">
+			<?php echo get_the_post_thumbnail( $pledge_id, 'pledge-logo' ); ?>
+		</div>
+	<?php endif; ?>
 	<div class="form-field form-field__logo">
 		<label for="5ftf-org-logo">
 			<?php esc_html_e( 'Logo', 'wporg-5ftf' ); ?>

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -4,8 +4,7 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 
 /** @var array $contributors */
-/** @var array $data */
-/** @var bool  $readonly */
+/** @var int   $pledge_id */
 ?>
 
 <script type="text/template" id="tmpl-5ftf-contributor-lists">
@@ -75,7 +74,7 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 </script> 
 
 <div id="5ftf-contributors">
-	<div class="pledge-contributors pledge-status__<?php echo esc_attr( get_post_status() ); ?>">
+	<div class="pledge-contributors pledge-status__<?php echo esc_attr( get_post_status( $pledge_id ) ); ?>">
 		<?php if ( ! empty( $contributors ) ) : ?>
 			<?php
 			printf(

--- a/themes/wporg-5ftf/css/objects/_pledge-form.scss
+++ b/themes/wporg-5ftf/css/objects/_pledge-form.scss
@@ -55,10 +55,67 @@
 		}
 	}
 	
-	input[type="submit"] {
+	input[type="submit"],
+	.button-primary {
 		display: inline-block;
 		height: auto;
 		padding: ms(-3) ms(0);
 		font-weight: 600;
+	}
+
+	.contributor-list-heading {
+		margin: 1rem 0;
+	}
+
+	.contributor-list {
+		margin-bottom: 1.5rem;
+
+		th,
+		td,
+		th *,
+		td * {
+			vertical-align: middle;
+		}
+
+		thead {
+			background-color: #fff;
+			color: inherit;
+
+			th {
+				border-bottom-color: $color-gray-light-700;
+			}
+		}
+
+		tr > * {
+			border-top-color: $color-gray-light-700;
+
+			&:first-child {
+				border-left-color: $color-gray-light-700;
+			}
+
+			&:last-child {
+				border-right-color: $color-gray-light-700;
+			}
+		}
+
+		tr:last-child > * {
+			border-bottom-color: $color-gray-light-700;
+		}
+
+		.avatar {
+			margin-right: 8px;
+		}
+
+		.button-link-delete {
+			text-decoration: none;
+
+			.dashicons {
+				margin-top: -2px;
+			}
+		}
+	}
+
+	.pledge-contributors.pledge-status__draft .resend-confirm {
+		display: none;
 	}
 }


### PR DESCRIPTION
Updates the "Manage Pledge" form to display the current pledge's data, and save edits to the basic meta (name, description, etc). This form requires an authentication token to display and save the content, which should verify that the person updating the form is the pledge admin.

Contributor updates & logo uploads will happen in following PRs.

Fixes #6, see #96.

![form](https://user-images.githubusercontent.com/541093/69385853-b5034080-0c8e-11ea-947f-e16b460f8ca1.png)

On a successful update:
![success](https://user-images.githubusercontent.com/541093/69385852-b5034080-0c8e-11ea-966e-aee739eff97e.png)

If the token is not valid, or the nonce expires, this error replaces the form:
![error](https://user-images.githubusercontent.com/541093/69385854-b59bd700-0c8e-11ea-8de8-242a31220335.png)

**To test**

- Create a Manage Pledge page with the shortcode `[5ftf_pledge_form_manage]`
- Create an authenticated manage link by using the "edit pledge" button, it will look like `/manage-pledge/?action=manage_pledge&pledge_id=[pledge_id]&auth_token=[token]`
- Alternately, any user with `manage_options` can edit a pledge, so while logged in you could visit `/manage-pledge/?action=manage_pledge&pledge_id=[pledge_id]`
- Try editing the pledge content 👍 

cc @melchoyce for any design feedback