### PR TITLE
Manage Pledge: Enable pledge admins to edit contributors from manage form

### DIFF
--- a/plugins/wporg-5ftf/assets/js/admin.js
+++ b/plugins/wporg-5ftf/assets/js/admin.js
@@ -1,6 +1,12 @@
 /* global ajaxurl, FiveForTheFuture, fftfContributors, jQuery */
 /* eslint no-alert: "off" */
 jQuery( document ).ready( function( $ ) {
+	let ajaxurl = window.ajaxurl;
+	// Set the ajax url if the global is undefined.
+	if ( 'undefined' === typeof ajaxurl ) {
+		ajaxurl = FiveForTheFuture.ajaxurl;
+	}
+
 	/**
 	 * Render the contributor lists using the contributors template into the pledge-contributors container. This
 	 * uses `_renderContributors` to render a list of contributors per status (published, pending).
@@ -68,6 +74,7 @@ jQuery( document ).ready( function( $ ) {
 				action: 'manage-contributors',
 				pledge_id: FiveForTheFuture.pledgeId,
 				_ajax_nonce: FiveForTheFuture.manageNonce,
+				_token: FiveForTheFuture.authToken,
 			}, data ),
 			success: callback,
 			dataType: 'json',
@@ -83,17 +90,19 @@ jQuery( document ).ready( function( $ ) {
 			return;
 		}
 
+		// Clear the error message field.
+		$( '#add-contrib-message' ).html( '' );
+
 		sendAjaxRequest( {
 			contributors: contribs,
 			manage_action: 'add-contributor',
 		}, function( response ) {
 			if ( ! response.success ) {
 				const $message = $( '<div>' )
-					.attr( 'id', 'add-contrib-message' )
 					.addClass( 'notice notice-error notice-alt' )
 					.append( $( '<p>' ).text( response.message ) );
 
-				$( '#add-contrib-message' ).replaceWith( $message );
+				$( '#add-contrib-message' ).html( $message );
 			} else if ( response.contributors ) {
 				render( response.contributors, container );
 				$( '#5ftf-pledge-contributors' ).val( '' );

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -248,6 +248,9 @@ function get_pledge_contributors( $pledge_id, $status = 'publish', $contributor_
  * @return array An array of contributor data, ready to be used in the JS templates.
  */
 function get_pledge_contributors_data( $pledge_id ) {
+	if ( ! $pledge_id ) {
+		return array();
+	}
 	$contrib_data = array();
 	$contributors = get_pledge_contributors( $pledge_id, 'all' );
 

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -8,7 +8,8 @@ namespace WordPressDotOrg\FiveForTheFuture\Endpoints;
 use WordPressDotOrg\FiveForTheFuture\{ Auth, Contributor, Email };
 use const WordPressDotOrg\FiveForTheFuture\PledgeMeta\META_PREFIX;
 
-add_action( 'wp_ajax_manage-contributors', __NAMESPACE__ . '\manage_contributors_handler' );
+add_action( 'wp_ajax_manage-contributors',        __NAMESPACE__ . '\manage_contributors_handler' );
+add_action( 'wp_ajax_nopriv_manage-contributors', __NAMESPACE__ . '\manage_contributors_handler' );
 
 add_action( 'wp_ajax_send-manage-email',        __NAMESPACE__ . '\send_manage_email_handler' );
 add_action( 'wp_ajax_nopriv_send-manage-email', __NAMESPACE__ . '\send_manage_email_handler' );

--- a/plugins/wporg-5ftf/includes/endpoints.php
+++ b/plugins/wporg-5ftf/includes/endpoints.php
@@ -30,7 +30,7 @@ function manage_contributors_handler() {
 	if ( is_wp_error( $authenticated ) ) {
 		wp_die( wp_json_encode( [
 			'success' => false,
-			'message' => $authenticated->get_error_message(),
+			'message' => __( 'Sorry, you don\'t have permissions to do that.', 'wporg-5ftf' ),
 		] ) );
 	}
 

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -175,8 +175,6 @@ function render_form_manage() {
 		return ob_get_clean();
 	}
 
-	$contributors = Contributor\get_pledge_contributors( $pledge_id, $status = 'all' );
-
 	if ( 'Update Pledge' === $action ) {
 		$results = process_form_manage( $pledge_id, $auth_token );
 
@@ -187,7 +185,8 @@ function render_form_manage() {
 		}
 	}
 
-	$data = PledgeMeta\get_pledge_meta( $pledge_id );
+	$data         = PledgeMeta\get_pledge_meta( $pledge_id );
+	$contributors = Contributor\get_pledge_contributors_data( $pledge_id );
 
 	ob_start();
 	$readonly = false;

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -213,7 +213,7 @@ function process_form_manage( $pledge_id, $auth_token ) {
 	 */
 	$can_view_form = Auth\can_manage_pledge( $pledge_id, $auth_token );
 
-	if ( ! $has_valid_nonce || ! $can_view_form ) {
+	if ( ! $has_valid_nonce || is_wp_error( $can_view_form ) ) {
 		return new WP_Error(
 			'invalid_token',
 			sprintf(

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -18,6 +18,7 @@ add_action( 'init',                   __NAMESPACE__ . '\schedule_cron_jobs' );
 add_action( 'admin_init',             __NAMESPACE__ . '\add_meta_boxes' );
 add_action( 'save_post',              __NAMESPACE__ . '\save_pledge', 10, 2 );
 add_action( 'admin_enqueue_scripts',  __NAMESPACE__ . '\enqueue_assets' );
+add_action( 'wp_enqueue_scripts',     __NAMESPACE__ . '\enqueue_assets' );
 add_action( 'transition_post_status', __NAMESPACE__ . '\maybe_update_single_cached_pledge_data', 10, 3 );
 add_action( 'update_all_cached_pledge_data', __NAMESPACE__. '\update_all_cached_pledge_data' );
 
@@ -503,9 +504,14 @@ function enqueue_assets() {
 	$ver = filemtime( FiveForTheFuture\PATH . '/assets/js/admin.js' );
 	wp_register_script( '5ftf-admin', plugins_url( 'assets/js/admin.js', __DIR__ ), [ 'jquery', 'wp-util' ], $ver );
 
+	$pledge_id   = is_admin() ? get_the_ID() : absint( $_REQUEST['pledge_id'] ?? 0 );
+	$auth_token  = sanitize_text_field( $_REQUEST['auth_token'] ?? '' );
 	$script_data = [
-		'pledgeId'    => get_the_ID(),
+		// The global ajaxurl is not set on the frontend.
+		'ajaxurl'     => admin_url( 'admin-ajax.php', 'relative' ),
+		'pledgeId'    => $pledge_id,
 		'manageNonce' => wp_create_nonce( 'manage-contributors' ),
+		'authToken'   => $auth_token,
 	];
 	wp_add_inline_script(
 		'5ftf-admin',
@@ -516,9 +522,16 @@ function enqueue_assets() {
 		'before'
 	);
 
-	$current_page = get_current_screen();
-	if ( Pledge\CPT_ID === $current_page->id ) {
-		wp_enqueue_style( '5ftf-admin' );
-		wp_enqueue_script( '5ftf-admin' );
+	if ( is_admin() ) {
+		$current_page = get_current_screen();
+		if ( Pledge\CPT_ID === $current_page->id ) {
+			wp_enqueue_style( '5ftf-admin' );
+			wp_enqueue_script( '5ftf-admin' );
+		}
+	} else {
+		global $post;
+		if ( $post instanceof WP_Post && has_shortcode( $post->post_content, '5ftf_pledge_form_manage' ) ) {
+			wp_enqueue_script( '5ftf-admin' );
+		}
 	}
 }

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -209,6 +209,7 @@ function add_meta_boxes() {
 function render_meta_boxes( $pledge, $box ) {
 	$readonly  = ! current_user_can( 'edit_page', $pledge->ID );
 	$is_manage = true;
+	$pledge_id = $pledge->ID;
 
 	$data = array();
 	foreach ( get_pledge_meta_config() as $key => $config ) {

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -6,7 +6,7 @@
 namespace WordPressDotOrg\FiveForTheFuture\PledgeMeta;
 
 use WordPressDotOrg\FiveForTheFuture;
-use WordPressDotOrg\FiveForTheFuture\{ Contributor, Email, Pledge, PledgeForm, XProfile };
+use WordPressDotOrg\FiveForTheFuture\{ Auth, Contributor, Email, Pledge, PledgeForm, XProfile };
 use WP_Post, WP_Error;
 
 defined( 'WPINC' ) || die();
@@ -531,8 +531,13 @@ function enqueue_assets() {
 		}
 	} else {
 		global $post;
-		if ( $post instanceof WP_Post && has_shortcode( $post->post_content, '5ftf_pledge_form_manage' ) ) {
-			wp_enqueue_script( '5ftf-admin' );
+		if ( is_a( $post, 'WP_Post' ) ) {
+			$pledge_id  = absint( $_REQUEST['pledge_id'] ?? 0 );
+			$auth_token = sanitize_text_field( $_REQUEST['auth_token'] ?? '' );
+			$can_manage = Auth\can_manage_pledge( $pledge_id, $auth_token );
+			if ( ! is_wp_error( $can_manage ) && has_shortcode( $post->post_content, '5ftf_pledge_form_manage' ) ) {
+				wp_enqueue_script( '5ftf-admin' );
+			}
 		}
 	}
 }

--- a/plugins/wporg-5ftf/views/form-pledge-manage.php
+++ b/plugins/wporg-5ftf/views/form-pledge-manage.php
@@ -33,6 +33,11 @@ require __DIR__ . '/partial-result-messages.php';
 				value="<?php esc_attr_e( 'Update Pledge', 'wporg-5ftf' ); ?>"
 			/>
 		</div>
+
+		<h2><?php esc_html_e( 'Contributors', 'wporg-5ftf' ); ?></h2>
+
+		<?php require get_views_path() . 'manage-contributors.php'; ?>
+
 	</form>
 
 <?php endif; ?>

--- a/plugins/wporg-5ftf/views/manage-contributors.php
+++ b/plugins/wporg-5ftf/views/manage-contributors.php
@@ -4,8 +4,7 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 
 /** @var array $contributors */
-/** @var array $data */
-/** @var bool  $readonly */
+/** @var int   $pledge_id */
 ?>
 
 <script type="text/template" id="tmpl-5ftf-contributor-lists">
@@ -75,7 +74,7 @@ use function WordPressDotOrg\FiveForTheFuture\get_views_path;
 </script> 
 
 <div id="5ftf-contributors">
-	<div class="pledge-contributors pledge-status__<?php echo esc_attr( get_post_status() ); ?>">
+	<div class="pledge-contributors pledge-status__<?php echo esc_attr( get_post_status( $pledge_id ) ); ?>">
 		<?php if ( ! empty( $contributors ) ) : ?>
 			<?php
 			printf(

--- a/themes/wporg-5ftf/css/objects/_pledge-form.scss
+++ b/themes/wporg-5ftf/css/objects/_pledge-form.scss
@@ -76,7 +76,32 @@
 		td * {
 			vertical-align: middle;
 		}
-		
+
+		thead {
+			background-color: #fff;
+			color: inherit;
+
+			th {
+				border-bottom-color: $color-gray-light-700;
+			}
+		}
+
+		tr > * {
+			border-top-color: $color-gray-light-700;
+
+			&:first-child {
+				border-left-color: $color-gray-light-700;
+			}
+
+			&:last-child {
+				border-right-color: $color-gray-light-700;
+			}
+		}
+
+		tr:last-child > * {
+			border-bottom-color: $color-gray-light-700;
+		}
+
 		.avatar {
 			margin-right: 8px;
 		}

--- a/themes/wporg-5ftf/css/objects/_pledge-form.scss
+++ b/themes/wporg-5ftf/css/objects/_pledge-form.scss
@@ -63,6 +63,10 @@
 		font-weight: 600;
 	}
 
+	.contributor-list-heading {
+		margin: 1rem 0;
+	}
+
 	.contributor-list {
 		margin-bottom: 1.5rem;
 
@@ -84,5 +88,9 @@
 				margin-top: -2px;
 			}
 		}
+	}
+
+	.pledge-contributors.pledge-status__draft .resend-confirm {
+		display: none;
 	}
 }

--- a/themes/wporg-5ftf/css/objects/_pledge-form.scss
+++ b/themes/wporg-5ftf/css/objects/_pledge-form.scss
@@ -55,10 +55,34 @@
 		}
 	}
 	
-	input[type="submit"] {
+	input[type="submit"],
+	.button-primary {
 		display: inline-block;
 		height: auto;
 		padding: ms(-3) ms(0);
 		font-weight: 600;
+	}
+
+	.contributor-list {
+		margin-bottom: 1.5rem;
+
+		th,
+		td,
+		th *,
+		td * {
+			vertical-align: middle;
+		}
+		
+		.avatar {
+			margin-right: 8px;
+		}
+
+		.button-link-delete {
+			text-decoration: none;
+
+			.dashicons {
+				margin-top: -2px;
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR brings the same manage contributor functionality from the admin dashboard to the front end manage form. A valid (auth token'ed) pledge admin can now add & remove contributors, and resend the confirmation emails from the manage pledge form.

This section is set below the "Update" button since it's a JS flow, this should prevent confusion about which submit button to use.

<img width="566" alt="Screen Shot 2019-11-22 at 3 49 01 PM" src="https://user-images.githubusercontent.com/541093/69459495-dcfeac80-0d3f-11ea-937d-9d328d37eff9.png">

**To test**

- Mange a pledge
- Add contributors with valid or invalid usernames, it should trigger the confirmation email
- Remove contributors, they should be removed from the pledge immediately
- Resend a contributor's confirmation email, should trigger the email

cc @melchoyce for design  👀 