### PR TITLE
Manage Pledge: Notify removed contributors

### DIFF
--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -2,7 +2,7 @@
 namespace WordPressDotOrg\FiveForTheFuture\Contributor;
 
 use WordPressDotOrg\FiveForTheFuture;
-use WordPressDotOrg\FiveForTheFuture\{ Pledge, XProfile };
+use WordPressDotOrg\FiveForTheFuture\{ Email, Pledge, XProfile };
 use WP_Error, WP_Post, WP_User;
 
 defined( 'WPINC' ) || die();
@@ -177,8 +177,13 @@ function add_pledge_contributors( $pledge_id, $contributors ) {
  * @return false|WP_Post|null
  */
 function remove_contributor( $contributor_post_id ) {
-	$pledge_id = get_post( $contributor_post_id )->post_parent;
-	$result    = wp_trash_post( $contributor_post_id );
+	$contributor = get_post( $contributor_post_id );
+	$pledge_id   = $contributor->post_parent;
+	$result      = wp_trash_post( $contributor_post_id );
+
+	if ( $result && 'publish' === $contributor->post_status ) {
+		Email\send_contributor_removed_email( $pledge_id, $contributor );
+	}
 
 	/**
 	 * Action: Fires when a contributor is removed from a pledge.

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -331,6 +331,7 @@ function get_contributor_user_ids( $contributor_posts ) {
 	";
 
 	$user_ids = $wpdb->get_col(
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- phpcs is confused by the variable, but it does correctly prepare.
 		$wpdb->prepare( $query, $usernames )
 	);
 

--- a/plugins/wporg-5ftf/includes/email.php
+++ b/plugins/wporg-5ftf/includes/email.php
@@ -126,9 +126,13 @@ function send_contributor_confirmation_emails( $pledge_id, $contributor_id = nul
  * @param WP_Post $contributor
  */
 function send_contributor_removed_email( $pledge_id, $contributor ) {
-	$pledge  = get_post( $pledge_id );
-	$subject = "Removed from {$pledge->post_title} sponsorship";
-	$message = "Howdy\n\n{$pledge->post_title} has removed you from their pledge.";
+	$pledge   = get_post( $pledge_id );
+	$subject  = "Removed from {$pledge->post_title} Five for the Future pledge";
+	$message  = "Howdy {$contributor->post_title},\n\n";
+	$message .= sprintf(
+		'This email is to notify you that your WordPress.org contributor profile is no longer linked to %1$s’s Five for the Future pledge. If this is unexpected news, it’s best to reach out directly to %1$s with questions. Have a great day!',
+		$pledge->post_title
+	);
 
 	$user = get_user_by( 'login', $contributor->post_title );
 	send_email( $user->user_email, $subject, $message, $pledge_id );

--- a/plugins/wporg-5ftf/includes/email.php
+++ b/plugins/wporg-5ftf/includes/email.php
@@ -115,9 +115,23 @@ function send_contributor_confirmation_emails( $pledge_id, $contributor_id = nul
 
 			"If {$pledge->post_title} isn't sponsoring your contributions, then you can ignore this email, and you won't be listed on their pledge.";
 
-		$user = get_user_by( 'login', $contributor->post_title );
 		send_email( $user->user_email, $subject, $message, $pledge_id );
 	}
+}
+
+/**
+ * Send the removed contributor an email to notify them after removal.
+ *
+ * @param int     $pledge_id
+ * @param WP_Post $contributor
+ */
+function send_contributor_removed_email( $pledge_id, $contributor ) {
+	$pledge  = get_post( $pledge_id );
+	$subject = "Removed from {$pledge->post_title} sponsorship";
+	$message = "Howdy\n\n{$pledge->post_title} has removed you from their pledge.";
+
+	$user = get_user_by( 'login', $contributor->post_title );
+	send_email( $user->user_email, $subject, $message, $pledge_id );
 }
 
 /**


### PR DESCRIPTION
This sends an email to contributors after they're removed from a pledge.

Current the email is very terse… 

```
Subject: Removed from [company] sponsorship

Howdy

[Company] has removed you from their pledge.
```

We could add something like "if this was a mistake…" but I don't think they should be contacting _us_ if it was a mistake, and I don't think we want to just give out the pledge admin's email. Otherwise I'm not sure what could go here. (cc @andreamiddleton for copy ideas)

**To test**

- Edit a pledge in wp-admin
- Remove a confirmed contributor, it should send that person an email
- Remove an unconfirmed contributor, no email is sent