### PR TITLE
Manage Pledge: Allow pledge admins to change email

### DIFF
--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -137,6 +137,11 @@ function render_form_manage() {
 			$errors = $results->get_error_messages();
 		} else {
 			$messages = array( __( 'Your pledge has been updated.', 'wporg-5ftf' ) );
+
+			$meta_key = PledgeMeta\META_PREFIX . 'pledge-email-confirmed';
+			if ( ! get_post( $pledge_id )->$meta_key ) {
+				$messages[] = __( 'You must confirm your new email address before it will be visible.', 'wporg-5ftf' );
+			}
 		}
 	}
 

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -15,6 +15,11 @@ defined( 'WPINC' ) || die();
 add_shortcode( '5ftf_pledge_form_new', __NAMESPACE__ . '\render_form_new' );
 add_shortcode( '5ftf_pledge_form_manage', __NAMESPACE__ . '\render_form_manage' );
 
+// Short-circuit out of both shortcodes for shared functionality (confirming admin email, resending the pledge
+// confirmation email).
+add_filter( 'pre_do_shortcode_tag', __NAMESPACE__ . '\process_confirmed_email', 10, 2 );
+add_filter( 'pre_do_shortcode_tag', __NAMESPACE__ . '\process_resend_confirm_email', 10, 2 );
+
 /**
  * Render the form(s) for creating new pledges.
  *
@@ -38,18 +43,6 @@ function render_form_new() {
 		} elseif ( is_int( $pledge_id ) ) {
 			$complete = true;
 		}
-	} elseif ( 'confirm_pledge_email' === $action ) {
-		$view             = 'form-pledge-confirm-email.php';
-		$pledge_id        = filter_input( INPUT_GET, 'pledge_id', FILTER_VALIDATE_INT );
-		$unverified_token = filter_input( INPUT_GET, 'auth_token', FILTER_SANITIZE_STRING );
-		$email_confirmed  = process_pledge_confirmation_email( $pledge_id, $action, $unverified_token );
-		$pledge           = get_post( $pledge_id );
-
-	} elseif ( filter_input( INPUT_GET, 'resend_pledge_confirmation' ) ) {
-		$pledge_id = filter_input( INPUT_GET, 'pledge_id', FILTER_VALIDATE_INT );
-		$complete  = true;
-
-		Email\send_pledge_confirmation_email( $pledge_id, get_post()->ID );
 	}
 
 	ob_start();
@@ -107,44 +100,6 @@ function process_form_new() {
 }
 
 /**
- * Process a request to confirm a company's email address.
- *
- * @param int    $pledge_id
- * @param string $action
- * @param array  $unverified_token
- *
- * @return bool
- */
-function process_pledge_confirmation_email( $pledge_id, $action, $unverified_token ) {
-	$meta_key          = PledgeMeta\META_PREFIX . 'pledge-email-confirmed';
-	$already_confirmed = get_post( $pledge_id )->$meta_key;
-
-	if ( $already_confirmed ) {
-		/*
-		 * If they refresh the page after confirming, they'd otherwise get an error because the token had been
-		 * used, and might be confused and think that the address wasn't confirmed.
-		 *
-		 * This leaks the fact that the address is confirmed, because it will return true even if the token is
-		 * invalid, but there aren't any security/privacy implications of that.
-		 */
-		return true;
-	}
-
-	$email_confirmed = Auth\is_valid_authentication_token( $pledge_id, $action, $unverified_token );
-
-	if ( $email_confirmed ) {
-		update_post_meta( $pledge_id, $meta_key, true );
-		wp_update_post( array(
-			'ID'          => $pledge_id,
-			'post_status' => 'publish',
-		) );
-		Email\send_contributor_confirmation_emails( $pledge_id );
-	}
-
-	return $email_confirmed;
-}
-
-/**
  * Render the form(s) for managing existing pledges.
  *
  * @return false|string
@@ -189,7 +144,7 @@ function render_form_manage() {
 	$contributors = Contributor\get_pledge_contributors_data( $pledge_id );
 
 	ob_start();
-	$readonly = false;
+	$readonly  = false;
 	$is_manage = true;
 	require FiveForTheFuture\PATH . 'views/form-pledge-manage.php';
 
@@ -224,7 +179,7 @@ function process_form_manage( $pledge_id, $auth_token ) {
 	}
 
 	$submission = get_form_submission();
-	$has_error = check_invalid_submission( $submission, 'update' );
+	$has_error  = check_invalid_submission( $submission, 'update' );
 	if ( $has_error ) {
 		return $has_error;
 	}
@@ -261,6 +216,96 @@ function process_form_manage( $pledge_id, $auth_token ) {
 }
 
 /**
+ * Process a request to confirm a company's email address.
+ *
+ * @param string|false $value Short-circuit return value.
+ * @param string       $tag   Shortcode name.
+ *
+ * @return bool|string
+ */
+function process_confirmed_email( $value, $tag ) {
+	if ( ! in_array( $tag, [ '5ftf_pledge_form_new', '5ftf_pledge_form_manage' ] ) ) {
+		return $value;
+	}
+
+	$action = sanitize_text_field( $_REQUEST['action'] ?? '' );
+	if ( 'confirm_pledge_email' !== $action ) {
+		return $value;
+	}
+
+	$pledge_id  = filter_input( INPUT_GET, 'pledge_id', FILTER_VALIDATE_INT );
+	$auth_token = filter_input( INPUT_GET, 'auth_token', FILTER_SANITIZE_STRING );
+
+	$meta_key          = PledgeMeta\META_PREFIX . 'pledge-email-confirmed';
+	$already_confirmed = get_post( $pledge_id )->$meta_key;
+	$email_confirmed   = false;
+	$is_new_pledge     = '5ftf_pledge_form_new' === $tag;
+
+	if ( $already_confirmed ) {
+		/*
+		 * If they refresh the page after confirming, they'd otherwise get an error because the token had been
+		 * used, and might be confused and think that the address wasn't confirmed.
+		 *
+		 * This leaks the fact that the address is confirmed, because it will return true even if the token is
+		 * invalid, but there aren't any security/privacy implications of that.
+		 */
+		$email_confirmed = true;
+	}
+
+	$email_confirmed = Auth\is_valid_authentication_token( $pledge_id, $action, $auth_token );
+
+	if ( $email_confirmed ) {
+		update_post_meta( $pledge_id, $meta_key, true );
+		wp_update_post( array(
+			'ID'          => $pledge_id,
+			'post_status' => 'publish',
+		) );
+		if ( $is_new_pledge ) {
+			Email\send_contributor_confirmation_emails( $pledge_id );
+		}
+	}
+
+	ob_start();
+	$directory_url = home_url( 'pledges' );
+	$pledge        = get_post( $pledge_id );
+	require FiveForTheFuture\get_views_path() . 'form-pledge-confirm-email.php';
+	return ob_get_clean();
+}
+
+/**
+ * Process a request to resed a company's confirmation email.
+ *
+ * @param string|false $value Short-circuit return value.
+ * @param string       $tag   Shortcode name.
+ *
+ * @return bool|string
+ */
+function process_resend_confirm_email( $value, $tag ) {
+	if ( ! in_array( $tag, [ '5ftf_pledge_form_new', '5ftf_pledge_form_manage' ] ) ) {
+		return $value;
+	}
+
+	$action = sanitize_text_field( $_REQUEST['action'] ?? '' );
+	if ( 'resend_pledge_confirmation' !== $action ) {
+		return $value;
+	}
+
+	$pledge_id = filter_input( INPUT_GET, 'pledge_id', FILTER_VALIDATE_INT );
+	Email\send_pledge_confirmation_email( $pledge_id, get_post()->ID );
+
+	$messages = array(
+		sprintf(
+			__( 'We’ve emailed you a new link to confirm your address for %s.', 'wporg-5ftf' ),
+			get_the_title( $pledge_id )
+		),
+	);
+
+	ob_start();
+	require FiveForTheFuture\get_views_path() . 'partial-result-messages.php';
+	return ob_get_clean();
+}
+
+/**
  * Get and sanitize $_POST values from a form submission.
  *
  * @return array
@@ -278,7 +323,7 @@ function get_form_submission() {
 
 	$result = filter_input_array( INPUT_POST, $input_filters );
 	if ( ! $result ) {
-		$result = array_fill_keys( array_keys( $input_filters ), '' );
+		$result               = array_fill_keys( array_keys( $input_filters ), '' );
 		$result['empty_post'] = true;
 	}
 

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -280,10 +280,11 @@ function save_pledge( $pledge_id, $pledge ) {
 
 	save_pledge_meta( $pledge_id, $submitted_meta );
 
+	// Fired if the "Resend Confirmation" button was clicked in wp-admin.
 	if ( filter_input( INPUT_POST, 'resend-pledge-confirmation' ) ) {
 		Email\send_pledge_confirmation_email(
 			filter_input( INPUT_GET, 'resend-pledge-id', FILTER_VALIDATE_INT ),
-			get_page_by_path( 'for-organizations' )->ID
+			get_page_by_path( 'manage-pledge' )->ID
 		);
 	}
 }
@@ -351,8 +352,8 @@ function update_generated_meta( $meta_id, $object_id, $meta_key, $_meta_value ) 
 			break;
 
 		case META_PREFIX . 'org-pledge-email':
-			$form_page_id = get_page_by_path( 'for-organizations' )->ID;
-			Email\send_pledge_confirmation_email( $object_id, $form_page_id );
+			$landing_page = get_page_by_path( 'manage-pledge' )->ID;
+			Email\send_pledge_confirmation_email( $object_id, $landing_page );
 			delete_post_meta( $object_id, META_PREFIX . 'pledge-email-confirmed' );
 			// Flip pledge back to pending.
 			wp_update_post( array(

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -350,8 +350,15 @@ function update_generated_meta( $meta_id, $object_id, $meta_key, $_meta_value ) 
 			update_post_meta( $object_id, META_PREFIX . 'org-domain', $domain );
 			break;
 
-		case META_PREFIX . 'pledge-email':
+		case META_PREFIX . 'org-pledge-email':
+			$form_page_id = get_page_by_path( 'for-organizations' )->ID;
+			Email\send_pledge_confirmation_email( $object_id, $form_page_id );
 			delete_post_meta( $object_id, META_PREFIX . 'pledge-email-confirmed' );
+			// Flip pledge back to pending.
+			wp_update_post( array(
+				'ID'          => $object_id,
+				'post_status' => 'pending',
+			) );
 			break;
 	}
 }

--- a/plugins/wporg-5ftf/views/form-pledge-confirm-email.php
+++ b/plugins/wporg-5ftf/views/form-pledge-confirm-email.php
@@ -4,8 +4,9 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 use WP_Post;
 
 /**
- * @var bool         $email_confirmed
  * @var string       $directory_url
+ * @var bool         $email_confirmed
+ * @var bool         $is_new_pledge
  * @var int          $pledge_id
  * @var WP_Post|null $pledge
  */
@@ -16,10 +17,17 @@ use WP_Post;
 	<div class="notice notice-success notice-alt">
 		<p>
 			<?php
-			printf(
-				wp_kses_post( __( 'Thank you for confirming your address! We’ve emailed confirmation links to the contributors you mentioned, and your pledge will show up in <a href=\"%s\">the directory</a> once one contributor confirms their participation.', 'wporg-5ftf' ) ),
-				esc_url( $directory_url )
-			);
+			if ( $is_new_pledge ) {
+				printf(
+					wp_kses_post( __( 'Thank you for confirming your address! We’ve emailed confirmation links to the contributors you mentioned, and your pledge will show up in <a href=\"%s\">the directory</a> once one contributor confirms their participation.', 'wporg-5ftf' ) ),
+					esc_url( $directory_url )
+				);
+			} else {
+				printf(
+					wp_kses_post( __( 'Thank you for confirming your address! If you have confirmed contributors, your pledge is visible in <a href=\"%s\">the directory</a> again. Otherwise, your pledge wiill show up once one contributor confirms their participation.', 'wporg-5ftf' ) ),
+					esc_url( $directory_url )
+				);
+			}
 			?>
 		</p>
 
@@ -54,11 +62,11 @@ use WP_Post;
 
 		<form action="" method="get">
 			<input type="hidden" name="pledge_id" value="<?php echo esc_attr( $pledge_id ); ?>" />
+			<input type="hidden" name="action" value="resend_pledge_confirmation" />
 
 			<p>
 				<input
 					type="submit"
-					name="resend_pledge_confirmation"
 					value="Resend Confirmation"
 				/>
 			</p>

--- a/plugins/wporg-5ftf/views/form-pledge-manage.php
+++ b/plugins/wporg-5ftf/views/form-pledge-manage.php
@@ -23,6 +23,7 @@ require __DIR__ . '/partial-result-messages.php';
 		wp_nonce_field( 'manage_pledge_' . $pledge_id );
 
 		require get_views_path() . 'inputs-pledge-org-info.php';
+		require get_views_path() . 'inputs-pledge-org-email.php';
 		?>
 
 		<div>

--- a/plugins/wporg-5ftf/views/inputs-pledge-org-email.php
+++ b/plugins/wporg-5ftf/views/inputs-pledge-org-email.php
@@ -25,9 +25,16 @@ use WP_Post;
 		aria-describedby="5ftf-pledge-email-help"
 		<?php echo $readonly ? 'readonly' : ''; ?>
 	/>
-	<p id="5ftf-pledge-email-help">
-		<?php esc_html_e( 'This address will be used to confirm your organization’s contribution profile, and later manage any changes. Please make sure that it’s a group address (e.g., wp-contributors@example.com) so that it persists across employee transitions.', 'wporg-5ftf' ); ?>
-	</p>
+	<div id="5ftf-pledge-email-help">
+		<p>
+			<?php esc_html_e( 'This address will be used to confirm your organization’s contribution profile, and later manage any changes. Please make sure that it’s a group address (e.g., wp-contributors@example.com) so that it persists across employee transitions.', 'wporg-5ftf' ); ?>
+		</p>
+		<?php if ( ! empty( $data['org-pledge-email'] ) ) : ?>
+			<p>
+				<?php esc_html_e( 'If you change this email, you will need to confirm the new email. Your pledge will be unpublished until the new email is confirmed.', 'wporg-5ftf' ); ?>
+			</p>
+		<?php endif; ?>
+	</div>
 
 	<?php if ( is_admin() ) : ?>
 		<?php if ( $data['pledge-email-confirmed'] ) : ?>

--- a/themes/wporg-5ftf/css/objects/_pledge-form.scss
+++ b/themes/wporg-5ftf/css/objects/_pledge-form.scss
@@ -29,7 +29,7 @@
 			height: auto;
 		}
 
-		> p {
+		[id*="help"] p {
 			margin-top: ms(-5);
 			font-size: ms(-2);
 		}


### PR DESCRIPTION
The pledge organization's email can now be changed on the manage form. Changing the email will flip the pledge back in to "Pending" status, until the new email is confirmed. This also fixes the process in wp-admin so that changing the email here will also require confirmation from the email owner.

Fixes #107 

<img width="677" alt="email" src="https://user-images.githubusercontent.com/541093/69582692-20a71f80-0fa7-11ea-9680-151bbda90cdc.png">

**To test**

- Manage a pledge
- Change the email, save
- You should no longer see the pledge in the pledges list
- You should get an email at the new address
- Confirming using that link will re-publish the pledge, all the contributors are left as-is so assuming there are confirmed contribs, it should show up in the peldge list again.