### PR TITLE
Pledge Management: Allow pledge admins to remove the pledge

### DIFF
--- a/plugins/wporg-5ftf/assets/js/admin.js
+++ b/plugins/wporg-5ftf/assets/js/admin.js
@@ -1,4 +1,4 @@
-/* global ajaxurl, FiveForTheFuture, fftfContributors, jQuery */
+/* global FiveForTheFuture, fftfContributors, jQuery */
 /* eslint no-alert: "off" */
 jQuery( document ).ready( function( $ ) {
 	let ajaxurl = window.ajaxurl;
@@ -151,6 +151,12 @@ jQuery( document ).ready( function( $ ) {
 		if ( 13 === event.which ) {
 			event.preventDefault();
 			_addContributors();
+		}
+	} );
+
+	$( '#5ftf-pledge-remove' ).on( 'click', function( event ) {
+		if ( ! confirm( FiveForTheFuture.removePrompt ) ) {
+			event.preventDefault();
 		}
 	} );
 } );

--- a/plugins/wporg-5ftf/assets/js/dialog.js
+++ b/plugins/wporg-5ftf/assets/js/dialog.js
@@ -1,4 +1,4 @@
-/* global FiveForTheFuture, jQuery */
+/* global FFTF_Dialog, jQuery */
 jQuery( document ).ready( function( $ ) {
 	const button = document.getElementById( 'toggle-management-link-form' );
 	const template = wp.template( '5ftf-send-link-dialog' );
@@ -84,12 +84,12 @@ jQuery( document ).ready( function( $ ) {
 		$( event.target.querySelector( '.message' ) ).html( '' );
 		$.ajax( {
 			type: 'POST',
-			url: FiveForTheFuture.ajaxurl,
+			url: FFTF_Dialog.ajaxurl,
 			data: {
 				action: 'send-manage-email',
-				pledge_id: FiveForTheFuture.pledgeId,
+				pledge_id: FFTF_Dialog.pledgeId,
 				email,
-				_ajax_nonce: FiveForTheFuture.ajaxNonce,
+				_ajax_nonce: FFTF_Dialog.ajaxNonce,
 			},
 			success( response ) {
 				if ( response.message ) {

--- a/plugins/wporg-5ftf/includes/email.php
+++ b/plugins/wporg-5ftf/includes/email.php
@@ -154,3 +154,25 @@ function send_manage_pledge_link( $pledge_id ) {
 
 	return $result;
 }
+
+/**
+ * Email pledge manager to notify that the pledge has been removed.
+ *
+ * @param WP_Post $pledge The pledge object, used to add the title now that the pledge itself has been deleted.
+ *
+ * @return bool
+ */
+function send_pledge_deactivation_email( $pledge ) {
+	$message = sprintf(
+		"Your organization, %s, has been removed from the Five for the Future listing.\n\n" .
+		'Please reply to this email if this was a mistake.',
+		$pledge->post_title
+	);
+
+	return send_email(
+		$pledge->{'5ftf_org-pledge-email'},
+		'Pledge removed from Five for the Future',
+		$message,
+		$pledge->ID
+	);
+}

--- a/plugins/wporg-5ftf/includes/pledge-form.php
+++ b/plugins/wporg-5ftf/includes/pledge-form.php
@@ -258,13 +258,7 @@ function process_form_remove( $pledge_id, $auth_token ) {
 		);
 	}
 
-	$result = wp_update_post(
-		array(
-			'ID'          => $pledge_id,
-			'post_status' => Pledge\DEACTIVE_STATUS,
-		),
-		true // Return a WP_Error.
-	);
+	$result = Pledge\deactivate( $pledge_id, true );
 
 	if ( is_wp_error( $result ) ) {
 		return $result;

--- a/plugins/wporg-5ftf/includes/pledge-meta.php
+++ b/plugins/wporg-5ftf/includes/pledge-meta.php
@@ -549,13 +549,14 @@ function enqueue_assets() {
 
 	$pledge_id   = is_admin() ? get_the_ID() : absint( $_REQUEST['pledge_id'] ?? 0 );
 	$auth_token  = sanitize_text_field( $_REQUEST['auth_token'] ?? '' );
-	$script_data = [
+	$script_data = array(
 		// The global ajaxurl is not set on the frontend.
 		'ajaxurl'     => admin_url( 'admin-ajax.php', 'relative' ),
 		'pledgeId'    => $pledge_id,
 		'manageNonce' => wp_create_nonce( 'manage-contributors' ),
 		'authToken'   => $auth_token,
-	];
+		'removePrompt' => __( 'Are you sure you want to remove this pledge?', 'wporg-5ftf' ),
+	);
 	wp_add_inline_script(
 		'5ftf-admin',
 		sprintf(

--- a/plugins/wporg-5ftf/includes/pledge.php
+++ b/plugins/wporg-5ftf/includes/pledge.php
@@ -462,21 +462,26 @@ function has_existing_pledge( $key, $key_type, int $current_pledge_id = 0 ) {
  * @return void
  */
 function enqueue_assets() {
-	wp_register_script( 'wicg-inert', plugins_url( 'assets/js/inert.min.js', __DIR__ ), [], '3.0.0', true );
+	wp_register_script( 'wicg-inert', plugins_url( 'assets/js/inert.min.js', __DIR__ ), array(), '3.0.0', true );
 
 	if ( CPT_ID === get_post_type() ) {
-		$ver = filemtime( FiveForTheFuture\PATH . '/assets/js/frontend.js' );
-		wp_enqueue_script( '5ftf-frontend', plugins_url( 'assets/js/frontend.js', __DIR__ ), [ 'jquery', 'wp-a11y', 'wp-util', 'wicg-inert' ], $ver, true );
+		wp_enqueue_script(
+			'5ftf-dialog',
+			plugins_url( 'assets/js/dialog.js', __DIR__ ),
+			array( 'jquery', 'wp-a11y', 'wp-util', 'wicg-inert' ),
+			filemtime( FiveForTheFuture\PATH . '/assets/js/dialog.js' ),
+			true
+		);
 
-		$script_data = [
-			'ajaxurl'   => admin_url( 'admin-ajax.php', 'relative' ), // The global ajaxurl is not set on the frontend.
-			'pledgeId'  => get_the_ID(),
-			'ajaxNonce' => wp_create_nonce( 'send-manage-email' ),
-		];
+		$script_data = array(
+			'ajaxurl'      => admin_url( 'admin-ajax.php', 'relative' ), // The global ajaxurl is not set on the frontend.
+			'pledgeId'     => get_the_ID(),
+			'ajaxNonce'    => wp_create_nonce( 'send-manage-email' ),
+		);
 		wp_add_inline_script(
-			'5ftf-frontend',
+			'5ftf-dialog',
 			sprintf(
-				'var FiveForTheFuture = JSON.parse( decodeURIComponent( \'%s\' ) );',
+				'var FFTF_Dialog = JSON.parse( decodeURIComponent( \'%s\' ) );',
 				rawurlencode( wp_json_encode( $script_data ) )
 			),
 			'before'

--- a/plugins/wporg-5ftf/includes/pledge.php
+++ b/plugins/wporg-5ftf/includes/pledge.php
@@ -205,10 +205,7 @@ function handle_activation_action( $post_id ) {
 	$sendback = remove_query_arg( [ 'deactivated', 'reactivated' ], $sendback );
 
 	if ( 'deactivate' === $action ) {
-		wp_update_post( array(
-			'ID'          => $post_id,
-			'post_status' => DEACTIVE_STATUS,
-		) );
+		deactivate( $post_id );
 		wp_redirect( add_query_arg( 'deactivated', 1, $sendback ) );
 		exit();
 	} else {
@@ -353,6 +350,31 @@ function create_new_pledge( $name ) {
 	}
 
 	return $pledge_id;
+}
+
+/**
+ * Remove a pledge from view by setting its status to "deactivated".
+ *
+ * @param int  $pledge_id The pledge to deactivate.
+ * @param bool $notify    Whether the pledge admin should be notified of the deactivation.
+ *
+ * @return int|WP_Error Post ID on success. Otherwise WP_Error.
+ */
+function deactivate( $pledge_id, $notify = false ) {
+	$pledge = get_post( $pledge_id );
+	$result = wp_update_post(
+		array(
+			'ID'          => $pledge_id,
+			'post_status' => DEACTIVE_STATUS,
+		),
+		true // Return a WP_Error.
+	);
+
+	if ( $notify && ! is_wp_error( $result ) ) {
+		Email\send_pledge_deactivation_email( $pledge );
+	}
+
+	return $result;
 }
 
 /**

--- a/plugins/wporg-5ftf/views/form-pledge-manage.php
+++ b/plugins/wporg-5ftf/views/form-pledge-manage.php
@@ -42,4 +42,6 @@ require __DIR__ . '/partial-result-messages.php';
 
 	</form>
 
+	<?php require get_views_path() . 'form-pledge-remove.php'; ?>
+
 <?php endif; ?>

--- a/plugins/wporg-5ftf/views/form-pledge-remove.php
+++ b/plugins/wporg-5ftf/views/form-pledge-remove.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WordPressDotOrg\FiveForTheFuture\View;
+
+/**
+ * @var bool   $can_view_form
+ * @var int    $pledge_id
+ * @var string $auth_token
+ */
+
+?>
+
+<hr />
+
+<form class="pledge-form" id="5ftf-form-pledge-remove" action="" method="post">
+	<h2><?php esc_html_e( 'Remove Pledge', 'wporg-5ftf' ); ?></h2>
+
+	<p>
+		<?php esc_html_e( 'This will remove your pledge from the Five for the Future listing. You will not be able to reactivate it or submit a new pledge for this company.', 'wporg-5ftf' ); ?>
+	</p>
+
+	<p>
+		<?php wp_nonce_field( 'remove_pledge_' . $pledge_id ); ?>
+		<input type="hidden" name="action" value="remove-pledge" />
+		<input type="hidden" name="auth_token" value="<?php echo esc_attr( $auth_token ); ?>" />
+		<input type="hidden" name="pledge_id" value="<?php echo absint( $pledge_id ); ?>" />
+		<button type="submit" class="button button-danger" id="5ftf-pledge-remove">
+			<?php esc_html_e( 'Remove Pledge', 'wporg-5ftf' ); ?>
+		</button>
+	</p>
+</form>

--- a/themes/wporg-5ftf/css/components/_pledge-single.scss
+++ b/themes/wporg-5ftf/css/components/_pledge-single.scss
@@ -31,6 +31,15 @@ body.single.single-5ftf_pledge {
 				margin-top: ms(2);
 			}
 		}
+
+		.pledge-status {
+			display: inline-block;
+			padding: 4px 12px;
+			font-size: ms(-1);
+			text-transform: uppercase;
+			background-color: $color-error-red;
+			color: white;
+		}
 	}
 
 	.entry-title {

--- a/themes/wporg-5ftf/css/objects/_pledge-form.scss
+++ b/themes/wporg-5ftf/css/objects/_pledge-form.scss
@@ -29,7 +29,8 @@
 			height: auto;
 		}
 
-		[id*="help"] p {
+		[id*="help"] p,
+		p[id*="help"] {
 			margin-top: ms(-5);
 			font-size: ms(-2);
 		}

--- a/themes/wporg-5ftf/single-5ftf_pledge.php
+++ b/themes/wporg-5ftf/single-5ftf_pledge.php
@@ -6,6 +6,7 @@ use WordPressDotOrg\FiveForTheFuture\XProfile;
 use WP_Post;
 
 use const WordPressDotOrg\FiveForTheFuture\PledgeMeta\META_PREFIX;
+use const WordPressDotOrg\FiveForTheFuture\Pledge\DEACTIVE_STATUS;
 
 $contribution_data = XProfile\get_aggregate_contributor_data_for_pledge( get_the_ID() );
 
@@ -30,6 +31,9 @@ get_header();
 		<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 			<header class="entry-header">
 				<div>
+					<?php if ( DEACTIVE_STATUS === get_post_status() ) : ?>
+						<span class="pledge-status"><?php esc_html_e( 'deactivated', 'wporg-5ftf' ); ?></span>
+					<?php endif; ?>
 					<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 					<span class="pledge-url">
 						<?php


### PR DESCRIPTION
This adds a new section to the Manage Pledge form to remove a pledge from the Five for the Future listing. After confirming, the pledge is set to "deactivated" status, and only a site editor can reactivate it. A deactivated page is not included in the pledge listing or as a single pledge, and can't be edited using the manage form.

Fixes #22 

**Screenshots**

The section on the Manage Pledge form:

![remove-form](https://user-images.githubusercontent.com/541093/70455036-89979880-1a79-11ea-81ca-873697c28506.png)

![remove-success](https://user-images.githubusercontent.com/541093/70455037-89979880-1a79-11ea-85a8-08e113082680.png)

If the pledge manager tries to edit the pledge again using the manage link, it won't work:

![manage-removed](https://user-images.githubusercontent.com/541093/70455035-89979880-1a79-11ea-8a80-a7711675f0f6.png)

**To test**

- Generate a manage link to manage a pledge
- Try removing the pledge
- It should work, and you should receive an email saying so
- It should log that the pledge was deactivated
