### PR TITLE
My Pledges: Require profile to be filled out before confirming a pledge

### DIFF
--- a/plugins/wporg-5ftf/views/list-my-pledges.php
+++ b/plugins/wporg-5ftf/views/list-my-pledges.php
@@ -16,6 +16,7 @@ use WP_User, WP_Post;
  */
 
 $has_contributions = $contributor_pending_posts || $contributor_publish_posts;
+$has_profile_data  = $profile_data['hours_per_week'] && $profile_data['team_names'];
 
 ?>
 
@@ -30,7 +31,7 @@ $has_contributions = $contributor_pending_posts || $contributor_publish_posts;
 			<?php esc_html_e( 'My Pledges', 'wporg-5ftf' ); ?>
 		</h1>
 
-		<?php if ( $profile_data['hours_per_week'] && $profile_data['team_names'] ) : ?>
+		<?php if ( $has_profile_data ) : ?>
 			<p class="my-pledges__dedication">
 				<?php echo esc_html( sprintf(
 					_n(
@@ -84,6 +85,17 @@ $has_contributions = $contributor_pending_posts || $contributor_publish_posts;
 
 			<div class="my-pledges__list is-pending-list">
 				<h2><?php esc_html_e( 'Pending Pledges', 'wporg-5ftf' ); ?></h2>
+
+				<?php if ( ! $has_profile_data ) : ?>
+					<div class="notice notice-error notice-alt">
+						<p>
+							<?php echo wp_kses_data( sprintf(
+								__( 'You need to <a href="%s">update your profile</a> before joining an organization.', 'wporg-5ftf' ),
+								'https://profiles.wordpress.org/me/profile/edit/group/5/'
+							) ); ?>
+						</p>
+					</div>
+				<?php endif; ?>
 
 				<?php
 				foreach ( $contributor_pending_posts as $contributor_post ) {

--- a/plugins/wporg-5ftf/views/single-my-pledge.php
+++ b/plugins/wporg-5ftf/views/single-my-pledge.php
@@ -4,6 +4,7 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 
 /**
  * @var WP_Post $contributor_post
+ * @var bool    $has_profile_data
  * @var WP_Post $pledge
  */
 
@@ -51,6 +52,9 @@ namespace WordPressDotOrg\FiveForTheFuture\View;
 					class="button button-default"
 					name="join_organization"
 					value="Join Organization"
+					<?php if ( ! $has_profile_data ) : ?>
+						disabled="disabled"
+					<?php endif; ?>
 				/>
 
 				<input


### PR DESCRIPTION
This will disable the "join organization" button until the profile is complete, and add a second warning message to explicitly tell the user why the button is disabled.

Fixes #93

I decided against spending the time to add inputs here that would submit to profiles.w.org, since it seemed fragile and like unnecessarily duplicating code. I also added a second warning above the pending pledges to make it clear why the button is disabled.

![Screen Shot 2019-12-10 at 4 42 33 PM](https://user-images.githubusercontent.com/541093/70571643-39e5c980-1b6c-11ea-92dc-e27b67ba4e91.png)

**To test**

- Pick a user that does not have profile data filled out, with a pending pledge contribution
- Go to `/my-pledges`
- The Join button should be disabled, clicking it will not let you join the org
- The Remove button is not disabled, in case it was a mistake
