### PR TITLE
My Pledges: Add an edit link to take you to your profile

### DIFF
--- a/plugins/wporg-5ftf/views/list-my-pledges.php
+++ b/plugins/wporg-5ftf/views/list-my-pledges.php
@@ -17,6 +17,11 @@ use WP_User, WP_Post;
 
 $has_contributions = $contributor_pending_posts || $contributor_publish_posts;
 
+$edit_link = sprintf(
+	'<a aria-label="%1$s" href="https://profiles.wordpress.org/me/profile/edit/group/5/">%2$s</a>',
+	__( 'edit hours pledged', 'wporg-5ftf' ),
+	__( '(edit)', 'wporg-5ftf' )
+);
 ?>
 
 <?php if ( is_user_logged_in() ) : ?>
@@ -32,15 +37,17 @@ $has_contributions = $contributor_pending_posts || $contributor_publish_posts;
 
 		<?php if ( $profile_data['hours_per_week'] && $profile_data['team_names'] ) : ?>
 			<p class="my-pledges__dedication">
-				<?php echo esc_html( sprintf(
+				<?php echo wp_kses_data( sprintf(
+					/* translators: %1$s is the number of hours, %2$s is the number of organizations, and %3$s is an edit link. */
 					_n(
-						'Pledged %1$s hours a week across %2$s organization',
-						'Pledged %1$s hours a week across %2$s organizations',
+						'Pledged <strong>%1$s hours a week</strong> %3$s across %2$s organization.',
+						'Pledged <strong>%1$s hours a week</strong> %3$s across %2$s organizations.',
 						count( $confirmed_pledge_ids ),
 						'wporg-5ftf'
 					),
 					$profile_data['hours_per_week'],
-					count( $confirmed_pledge_ids )
+					count( $confirmed_pledge_ids ),
+					$edit_link
 				) ); ?>
 			</p>
 

--- a/plugins/wporg-5ftf/views/list-my-pledges.php
+++ b/plugins/wporg-5ftf/views/list-my-pledges.php
@@ -104,7 +104,10 @@ $edit_link = sprintf(
 
 	<?php else : ?>
 
-		<p>You don't currently have any sponsorships. If your employer is sponsoring part of your time to contribute to WordPress, please ask them to <a href="<?php echo esc_url( $pledge_url ); ?>">submit a pledge</a> and list you as a contributor.</p>
+		<?php echo wp_kses_data( sprintf(
+			__( 'You don’t currently have any sponsorships. If your employer is sponsoring part of your time to contribute to WordPress, please ask them to <a href="%s">submit a pledge</a> and list you as a contributor.', 'wporg-5ftf' ),
+			esc_url( $pledge_url )
+		) ); ?>
 
 		<?php // todo add some resources here about how they can convince their boss to sponsor some of their time? ?>
 
@@ -124,7 +127,10 @@ $edit_link = sprintf(
 
 	<div class="notice notice-error notice-alt">
 		<p>
-			Please <a href="<?php echo esc_url( wp_login_url( get_permalink() ) ); ?>">log in to your WordPress.org account</a> in order to view your pledges.
+			<?php echo wp_kses_data( sprintf(
+				__( 'Please <a href="%s">log in to your WordPress.org account</a> in order to view your pledges.', 'wporg-5ftf' ),
+				esc_url( wp_login_url( get_permalink() ) )
+			) ); ?>
 		</p>
 	</div>
 


### PR DESCRIPTION
Fixes #89

![Screen Shot 2019-12-10 at 7 11 57 PM](https://user-images.githubusercontent.com/541093/70580217-f5b0f400-1b80-11ea-8a66-3489ae698067.png)

**To test**

- Go to `my-pledges`
- You should see the edit link
- It should take you to the profiles.w.org page to edit your contributions

cc @melchoyce 