### PR TITLE
Pledge List: Change list order hourly

### DIFF
--- a/plugins/wporg-5ftf/includes/pledge.php
+++ b/plugins/wporg-5ftf/includes/pledge.php
@@ -425,7 +425,8 @@ function filter_query( $query ) {
 				break;
 
 			default:
-				$query->set( 'orderby', 'rand' );
+				$date = date( 'Ymd' );
+				$query->set( 'orderby', "RAND($date)" );
 				break;
 		}
 	}

--- a/plugins/wporg-5ftf/includes/pledge.php
+++ b/plugins/wporg-5ftf/includes/pledge.php
@@ -430,10 +430,6 @@ function filter_query( $query ) {
 				break;
 		}
 	}
-
-	// todo remove this when `rand` pagination fixed
-	// see https://github.com/WordPress/five-for-the-future/issues/70#issuecomment-549066883.
-	$query->set( 'posts_per_page', 100 );
 }
 
 /**

--- a/plugins/wporg-5ftf/includes/pledge.php
+++ b/plugins/wporg-5ftf/includes/pledge.php
@@ -425,7 +425,7 @@ function filter_query( $query ) {
 				break;
 
 			default:
-				$date = date( 'Ymd' );
+				$date = date( 'YmdH' );
 				$query->set( 'orderby', "RAND($date)" );
 				break;
 		}


### PR DESCRIPTION
Using a seed for the RAND function, based on the date & time, will randomize the list every hour, while keeping the order consistent across any pagination. This also removes the increase to `posts_per_page`, since pagination is functional again.

Fixes #70 

Note: I changed the setting in wp-admin to show 20 posts per page, since 10 seemed too few. Since the code limit has been removed, this can continue to be tweaked in wp-admin if we need to.

**To test**

- Make sure the pledges list is random, but not changing per-reload
- Make sure the other sort orders still work