### PR TITLE
Pledge List: Add sorting by total contributor count

### DIFF
--- a/plugins/wporg-5ftf/includes/pledge.php
+++ b/plugins/wporg-5ftf/includes/pledge.php
@@ -435,6 +435,12 @@ function filter_query( $query ) {
 				$query->set( 'order', 'DESC' );
 				break;
 
+			case 'contributors':
+				$query->set( 'meta_key', $contributor_count_key );
+				$query->set( 'orderby', 'meta_value_num' );
+				$query->set( 'order', 'DESC' );
+				break;
+
 			default:
 				$query->set( 'orderby', 'rand' );
 				break;

--- a/themes/wporg-5ftf/archive-5ftf_pledge.php
+++ b/themes/wporg-5ftf/archive-5ftf_pledge.php
@@ -37,6 +37,9 @@ get_header(); ?>
 						<option value="alphabetical" <?php selected( $pledge_order, 'alphabetical' ); ?>>
 							<?php esc_html_e( 'Alphabetical', 'wporg-5ftf' ); ?>
 						</option>
+						<option value="contributors" <?php selected( $pledge_order, 'contributors' ); ?>>
+							<?php esc_html_e( 'Total Contributors', 'wporg-5ftf' ); ?>
+						</option>
 						<option value="hours" <?php selected( $pledge_order, 'hours' ); ?>>
 							<?php esc_html_e( 'Total Hours', 'wporg-5ftf' ); ?>
 						</option>


### PR DESCRIPTION
Add a "Total Contributors" option to the sorting menu on the pledge list. This will sort the list from most confirmed contributors to least. 

Fixes #94.

<img width="400" alt="Screen Shot 2019-12-11 at 4 42 09 PM" src="https://user-images.githubusercontent.com/541093/70662899-310cfa80-1c35-11ea-9c13-67a8f7d5c393.png">

**To test**

- View pledge list
- Sort by "Total Contributors"
- It should sort as expected. There's no visible count,  but you can check based on the small avatars
