### PR TITLE
Add in hover & visited styles for link buttons to stop global gutenberg styles from being applied.

### DIFF
--- a/themes/wporg-5ftf/css/objects/_buttons.scss
+++ b/themes/wporg-5ftf/css/objects/_buttons.scss
@@ -10,6 +10,11 @@
 	background: none;
 	color: $color__link-button;
 	text-decoration: none;
+
+	&:hover,
+	&:visited {
+		color: $color__link-button;		
+	}
 }
 
 // Add "danger" button styles, red text on grey background.

--- a/themes/wporg-5ftf/functions.php
+++ b/themes/wporg-5ftf/functions.php
@@ -123,7 +123,7 @@ add_action( 'after_setup_theme', __NAMESPACE__ . '\content_width', 0 );
  * Enqueue scripts and styles.
  */
 function scripts() {
-	wp_enqueue_style( 'wporg-style', get_theme_file_uri( '/css/style.css' ), [ 'dashicons', 'open-sans' ], '20191216' );
+	wp_enqueue_style( 'wporg-style', get_theme_file_uri( '/css/style.css' ), [ 'dashicons', 'open-sans' ], '20200423' );
 
 	wp_enqueue_script( 'wporg-navigation', get_template_directory_uri() . '/js/navigation.js', array(), '20181209', true );
 	wp_enqueue_script( 'wporg-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151215', true );


### PR DESCRIPTION
I initially made these changes directly in dotOrg repo. Replicating them here.

https://meta.trac.wordpress.org/ticket/5164