### PR TITLE
Send notification emails when contributors are inactive

### DIFF
--- a/.env/0-sandbox.php
+++ b/.env/0-sandbox.php
@@ -13,3 +13,12 @@ namespace {
 	function bump_stats_extra( $name, $value, $views = 1 ) {
 	}
 }
+
+namespace WordPressdotorg\MU_Plugins\Helpers {
+	/**
+	 * Stub.
+	 */
+	function natural_language_join( array $list, $conjunction = 'and' ): string {
+		return implode( ', ', $list );
+	}
+}

--- a/plugins/wporg-5ftf/includes/email.php
+++ b/plugins/wporg-5ftf/includes/email.php
@@ -25,7 +25,7 @@ defined( 'WPINC' ) || die();
  */
 function send_email( $to, $subject, $message, $pledge_id = false ) {
 	$headers = array(
-		'From: WordPress - Five for the Future <donotreply@wordpress.org>',
+		'From: WordPress - Five for the Future <bounce@wordpress.org>',
 		'Reply-To: getinvolved@wordpress.org',
 	);
 

--- a/plugins/wporg-5ftf/includes/xprofile.php
+++ b/plugins/wporg-5ftf/includes/xprofile.php
@@ -97,7 +97,7 @@ function get_xprofile_contribution_data( array $user_ids ) {
 }
 
 /**
- * Reindex the values by user ID, normalize it, and format it.
+ * Reindex `bpmain_bp_xprofile_data` rows by user ID, normalize it, and format it.
  *
  * This makes the data much easier to work with in many cases.
  *


### PR DESCRIPTION
Fixes most of #27, but doesn't send an email to the sponsoring company. That can be a future iteration while @angelasjin is working on the details of that.

This sends the email to folks that haven't logged in in 3 months. Once #119 and #189 are done, we can update it to look at 5ftF contributions specifically.

It needs polishing, but I think it's close to a state that I'm happy with, and close enough to get some review while I finish the polishing.

I initially tried using more complex SQL queries to reduce the number of rows that would be fetched, and the amount of PHP code needed, but that ended up being more trouble than it was worth.

See #205 for a discussion about the email copy.