### PR TITLE
Updated CSS for hyperlink color readability issue.

### DIFF
--- a/themes/wporg-5ftf/css/utilities/_colors.scss
+++ b/themes/wporg-5ftf/css/utilities/_colors.scss
@@ -4,6 +4,10 @@
 
 .has-wporg-blue-background-color {
 	background-color: $color__wporg-blue;
+
+	&.has-wporg-white-color a {
+		color: $color__text-on-dark;
+	}
 }
 
 .has-wporg-purple-color {


### PR DESCRIPTION
Added the code to make the link color white when the background is set to blue.

As per the issue - #208