### PR TITLE
Add stats for the % of contributors that are active.

### DIFF
--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -790,6 +790,7 @@ function prune_unnotifiable_users( array $contributors ) : array {
  * Determine if a contributor is active or not.
  *
  * Currently this only tracks the last login, but in the future it will be expanded to be more granular.
+ *
  * @link https://github.com/WordPress/five-for-the-future/issues/210
  */
 function is_active( int $last_login ) : bool {

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -760,7 +760,7 @@ function prune_unnotifiable_users( array $contributors ) : array {
 	$inactivity_threshold = strtotime( INACTIVITY_THRESHOLD_MONTHS . ' months ago' );
 
 	foreach ( $contributors as $index => $contributor ) {
-		if ( $contributor['last_logged_in'] > $inactivity_threshold ) {
+		if ( is_active( $contributor['last_logged_in'] ) ) {
 			unset( $contributors[ $index ] );
 		}
 
@@ -770,6 +770,18 @@ function prune_unnotifiable_users( array $contributors ) : array {
 	}
 
 	return $contributors;
+}
+
+/**
+ * Determine if a contributor is active or not.
+ *
+ * Currently this only tracks the last login, but in the future it will be expanded to be more granular.
+ * @link https://github.com/WordPress/five-for-the-future/issues/210
+ */
+function is_active( int $last_login ) : bool {
+	$inactivity_threshold = strtotime( INACTIVITY_THRESHOLD_MONTHS . ' months ago' );
+
+	return $last_login > $inactivity_threshold;
 }
 
 /**

--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -745,7 +745,7 @@ function add_user_data_to_xprofile( array $xprofiles ) : array {
 
 		$full_user['last_logged_in']             = intval( strtotime( $full_user['last_logged_in'] ?? '' ) ); // Convert `false` to `0`.
 		$full_user['5ftf_last_inactivity_email'] = intval( $full_user['5ftf_last_inactivity_email'] ?? 0 );
-		$full_user['teams_names']                = (array) maybe_unserialize( $xprofiles[ $user->ID ]->team_names );
+		$full_user['team_names']                 = (array) maybe_unserialize( $xprofiles[ $user->ID ]->team_names );
 
 		$full_users[] = $full_user;
 	}

--- a/plugins/wporg-5ftf/includes/email.php
+++ b/plugins/wporg-5ftf/includes/email.php
@@ -222,7 +222,7 @@ function send_contributor_inactive_email( array $contributor ) : bool {
 		$team = str_replace( 'Team', '', $team );
 
 		return trim( $team );
-	}, $contributor['teams_names'] );
+	}, $contributor['team_names'] );
 
 	$message = sprintf( "
 		Hi %s, a while ago you pledged to contribute %d %s a week to the %s %s:
@@ -250,7 +250,7 @@ function send_contributor_inactive_email( array $contributor ) : bool {
 		$contributor['hours_per_week'],
 		1 === $contributor['hours_per_week'] ? 'hour' : 'hours',
 		natural_language_join( $short_team_names ),
-		1 === count( $contributor['teams_names'] ) ? 'team' : 'teams',
+		1 === count( $contributor['team_names'] ) ? 'team' : 'teams',
 		$contributor['user_nicename']
 	);
 	$message = str_replace( "\t", '', trim( $message ) );

--- a/plugins/wporg-5ftf/includes/stats.php
+++ b/plugins/wporg-5ftf/includes/stats.php
@@ -157,7 +157,7 @@ function get_snapshot_data() {
 
 		$team_contributor_key = sprintf( 'team_%s_contributors', $attribution_prefix );
 
-		$snapshot_data[ $attribution_prefix . '_hours'] += $user['hours_per_week'];
+		$snapshot_data[ $attribution_prefix . '_hours' ] += $user['hours_per_week'];
 
 		foreach ( $user['team_names'] as $team ) {
 			if ( isset( $snapshot_data[ $team_contributor_key ][ $team ] ) ) {

--- a/plugins/wporg-5ftf/includes/xprofile.php
+++ b/plugins/wporg-5ftf/includes/xprofile.php
@@ -59,7 +59,7 @@ function get_all_xprofile_contributor_hours_teams() : array {
 
 		$user->user_id        = absint( $user->user_id );
 		$user->hours_per_week = absint( $user->hours_per_week ?? 0 );
-		$user->team_names     = (array) $user->team_names ?? array();
+		$user->team_names     = (array) ( $user->team_names ?? array() );
 
 		if ( 0 >= $user->hours_per_week || empty( $user->team_names ) ) {
 			unset( $users[ $user_index ] );

--- a/plugins/wporg-5ftf/tests/bootstrap.php
+++ b/plugins/wporg-5ftf/tests/bootstrap.php
@@ -22,6 +22,7 @@ require_once $_tests_dir . '/includes/functions.php';
  */
 function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/index.php';
+	require __DIR__ . '/helpers.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 

--- a/plugins/wporg-5ftf/tests/helpers.php
+++ b/plugins/wporg-5ftf/tests/helpers.php
@@ -28,28 +28,28 @@ function database_setup_before_class( WP_UnitTest_Factory $factory ) : array {
 		ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb3
 	" );
 
-	// Users
+	// Users.
 	$fixtures['users']['jane'] = $factory->user->create_and_get( array(
 		'user_login' => 'jane',
 		'user_email' => 'jane@example.org',
 		'meta_input' => array(
-			'last_logged_in' => date( 'Y-m-d H:i:s', strtotime( '95 days ago' ) )
-		)
+			'last_logged_in' => gmdate( 'Y-m-d H:i:s', strtotime( '95 days ago' ) ),
+		),
 	) );
 
 	$fixtures['users']['ashish'] = $factory->user->create_and_get( array(
 		'user_login' => 'ashish',
 		'user_email' => 'ashish@example.org',
 		'meta_input' => array(
-			'last_logged_in' => date( 'Y-m-d H:i:s', strtotime( '2 hours ago' ) )
-		)
+			'last_logged_in' => gmdate( 'Y-m-d H:i:s', strtotime( '2 hours ago' ) ),
+		),
 	) );
 
 	// Some users don't have any of the expected fields, so make sure they're included in tests.
 	$fixtures['users']['kimi'] = $factory->user->create_and_get( array(
 		'user_login' => 'kimi',
 		'user_email' => 'kimi@example.org',
-		'meta_input' => array()
+		'meta_input' => array(),
 	) );
 	delete_user_meta( $fixtures['users']['kimi']->ID, 'first_name' );
 
@@ -57,28 +57,29 @@ function database_setup_before_class( WP_UnitTest_Factory $factory ) : array {
 		'user_login' => 'andrea',
 		'user_email' => 'andrea@example.org',
 		'meta_input' => array(
-			'last_logged_in' => date( 'Y-m-d H:i:s', strtotime( '1 week ago' ) )
-		)
+			'last_logged_in' => gmdate( 'Y-m-d H:i:s', strtotime( '1 week ago' ) ),
+		),
 	) );
 
 	$fixtures['users']['caleb'] = $factory->user->create_and_get( array(
 		'user_login' => 'caleb',
 		'user_email' => 'caleb@example.org',
 		'meta_input' => array(
-			'last_logged_in' => date( 'Y-m-d H:i:s', strtotime( '4 months ago' ) )
-		)
+			'last_logged_in' => gmdate( 'Y-m-d H:i:s', strtotime( '4 months ago' ) ),
+		),
 	) );
 
-	// Pages
+	// Pages.
 	$for_organizations = $factory->post->create_and_get( array(
 		'post_type'   => 'page',
 		'post_title'  => 'For Organizations',
 		'post_status' => 'publish',
 	) );
 	$fixtures['pages']['for_organizations'] = $for_organizations;
+	// phpcs:ignore -- Overriding the global is required to mock a real environment.
 	$GLOBALS['post'] = $for_organizations; // `create_new_pledge()` assumes this exists.
 
-	// Pledges
+	// Pledges.
 	$tenup_id    = Pledge\create_new_pledge( '10up' );
 	$bluehost_id = Pledge\create_new_pledge( 'BlueHost' );
 

--- a/plugins/wporg-5ftf/tests/helpers.php
+++ b/plugins/wporg-5ftf/tests/helpers.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace WordPressDotOrg\FiveForTheFuture\Tests\Helpers;
+use WordPressDotOrg\FiveForTheFuture\{ Pledge };
+use WP_UnitTest_Factory;
+
+/**
+ * Sets up the database before a test class is loaded.
+ *
+ * Call in `set_up_before_class()`.
+ */
+function database_setup_before_class( WP_UnitTest_Factory $factory ) : array {
+	global $wpdb;
+
+	$fixtures = array();
+
+	$wpdb->query( "
+		CREATE TABLE `bpmain_bp_xprofile_data` (
+			`id` bigint unsigned NOT NULL AUTO_INCREMENT,
+			`field_id` bigint unsigned NOT NULL DEFAULT '0',
+			`user_id` bigint unsigned NOT NULL DEFAULT '0',
+			`value` longtext NOT NULL,
+			`last_updated` datetime NOT NULL DEFAULT '1970-01-01 00:00:00',
+			PRIMARY KEY (`id`),
+			KEY `field_id` (`field_id`),
+			KEY `user_id` (`user_id`)
+		)
+		ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb3
+	" );
+
+	// Users
+	$fixtures['users']['jane'] = $factory->user->create_and_get( array(
+		'user_login' => 'jane',
+		'user_email' => 'jane@example.org',
+	) );
+
+	$fixtures['users']['ashish'] = $factory->user->create_and_get( array(
+		'user_login' => 'ashish',
+		'user_email' => 'ashish@example.org',
+	) );
+
+	// Pages
+	$for_organizations = $factory->post->create_and_get( array(
+		'post_type'   => 'page',
+		'post_title'  => 'For Organizations',
+		'post_status' => 'publish',
+	) );
+	$fixtures['pages']['for_organizations'] = $for_organizations;
+	$GLOBALS['post'] = $for_organizations; // `create_new_pledge()` assumes this exists.
+
+	// Pledges
+	$tenup_id    = Pledge\create_new_pledge( '10up' );
+	$bluehost_id = Pledge\create_new_pledge( 'BlueHost' );
+
+	wp_update_post( array(
+		'ID'          => $tenup_id,
+		'post_status' => 'publish',
+	) );
+	wp_update_post( array(
+		'ID'          => $bluehost_id,
+		'post_status' => 'publish',
+	) );
+
+	$fixtures['pledges']['10up']     = get_post( $tenup_id );
+	$fixtures['pledges']['bluehost'] = get_post( $bluehost_id );
+
+	return $fixtures;
+}
+
+/**
+ * Sets up the database before a test is ran.
+ *
+ * Call in `set_up()`.
+ */
+function database_set_up( int $jane_id, int $ashish_id ) : void {
+	global $wpdb;
+
+	$wpdb->query( 'TRUNCATE TABLE `bpmain_bp_xprofile_data` ' );
+
+	$wpdb->query( $wpdb->prepare( "
+		INSERT INTO `bpmain_bp_xprofile_data`
+		(`id`, `field_id`, `user_id`, `value`, `last_updated`)
+		VALUES
+			(NULL, 29, %d, '40', '2019-12-02 10:00:00' ),
+			(NULL, 30, %d, 'a:1:{i:0;s:9:\"Core Team\";}', '2019-12-03 11:00:00' ),
+			(NULL, 29, %d, '35', '2019-12-02 10:00:00' ),
+			(NULL, 30, %d, 'a:1:{i:0;s:18:\"Documentation Team\";}', '2019-12-03 11:00:00' )",
+		$jane_id,
+		$jane_id,
+		$ashish_id,
+		$ashish_id
+	) );
+}
+
+/**
+ * Tears down the database after all tests in a class have ran.
+ *
+ * Call in `tear_down_after_class()`.
+ */
+function database_tear_down_after_class() : void {
+	global $wpdb;
+
+	$wpdb->query( 'DROP TABLE `bpmain_bp_xprofile_data` ' );
+}

--- a/plugins/wporg-5ftf/tests/helpers.php
+++ b/plugins/wporg-5ftf/tests/helpers.php
@@ -32,11 +32,33 @@ function database_setup_before_class( WP_UnitTest_Factory $factory ) : array {
 	$fixtures['users']['jane'] = $factory->user->create_and_get( array(
 		'user_login' => 'jane',
 		'user_email' => 'jane@example.org',
+		'meta_input' => array(
+			'last_logged_in' => date( 'Y-m-d H:i:s', strtotime( '95 days ago' ) )
+		)
 	) );
 
 	$fixtures['users']['ashish'] = $factory->user->create_and_get( array(
 		'user_login' => 'ashish',
 		'user_email' => 'ashish@example.org',
+		'meta_input' => array(
+			'last_logged_in' => date( 'Y-m-d H:i:s', strtotime( '2 hours ago' ) )
+		)
+	) );
+
+	$fixtures['users']['andrea'] = $factory->user->create_and_get( array(
+		'user_login' => 'andrea',
+		'user_email' => 'andrea@example.org',
+		'meta_input' => array(
+			'last_logged_in' => date( 'Y-m-d H:i:s', strtotime( '1 week ago' ) )
+		)
+	) );
+
+	$fixtures['users']['caleb'] = $factory->user->create_and_get( array(
+		'user_login' => 'caleb',
+		'user_email' => 'caleb@example.org',
+		'meta_input' => array(
+			'last_logged_in' => date( 'Y-m-d H:i:s', strtotime( '4 months ago' ) )
+		)
 	) );
 
 	// Pages
@@ -72,7 +94,7 @@ function database_setup_before_class( WP_UnitTest_Factory $factory ) : array {
  *
  * Call in `set_up()`.
  */
-function database_set_up( int $jane_id, int $ashish_id ) : void {
+function database_set_up( array $user_ids ) : void {
 	global $wpdb;
 
 	$wpdb->query( 'TRUNCATE TABLE `bpmain_bp_xprofile_data` ' );
@@ -84,11 +106,19 @@ function database_set_up( int $jane_id, int $ashish_id ) : void {
 			(NULL, 29, %d, '40', '2019-12-02 10:00:00' ),
 			(NULL, 30, %d, 'a:1:{i:0;s:9:\"Core Team\";}', '2019-12-03 11:00:00' ),
 			(NULL, 29, %d, '35', '2019-12-02 10:00:00' ),
-			(NULL, 30, %d, 'a:1:{i:0;s:18:\"Documentation Team\";}', '2019-12-03 11:00:00' )",
-		$jane_id,
-		$jane_id,
-		$ashish_id,
-		$ashish_id
+			(NULL, 30, %d, 'a:1:{i:0;s:18:\"Documentation Team\";}', '2019-12-03 11:00:00' ),
+			(NULL, 29, %d, '7', '2019-12-02 10:00:00' ),
+			(NULL, 30, %d, 'a:1:{i:0;s:14:\"Polyglots Team\";}', '2019-12-03 11:00:00' ),
+			(NULL, 29, %d, '4', '2019-12-02 10:00:00' ),
+			(NULL, 30, %d, 'a:1:{i:0;s:9:\"Meta Team\";}', '2019-12-03 11:00:00' )",
+		$user_ids[0],
+		$user_ids[0],
+		$user_ids[1],
+		$user_ids[1],
+		$user_ids[2],
+		$user_ids[2],
+		$user_ids[3],
+		$user_ids[3]
 	) );
 }
 

--- a/plugins/wporg-5ftf/tests/helpers.php
+++ b/plugins/wporg-5ftf/tests/helpers.php
@@ -45,6 +45,14 @@ function database_setup_before_class( WP_UnitTest_Factory $factory ) : array {
 		)
 	) );
 
+	// Some users don't have any of the expected fields, so make sure they're included in tests.
+	$fixtures['users']['kimi'] = $factory->user->create_and_get( array(
+		'user_login' => 'kimi',
+		'user_email' => 'kimi@example.org',
+		'meta_input' => array()
+	) );
+	delete_user_meta( $fixtures['users']['kimi']->ID, 'first_name' );
+
 	$fixtures['users']['andrea'] = $factory->user->create_and_get( array(
 		'user_login' => 'andrea',
 		'user_email' => 'andrea@example.org',
@@ -107,6 +115,8 @@ function database_set_up( array $user_ids ) : void {
 			(NULL, 30, %d, 'a:1:{i:0;s:9:\"Core Team\";}', '2019-12-03 11:00:00' ),
 			(NULL, 29, %d, '35', '2019-12-02 10:00:00' ),
 			(NULL, 30, %d, 'a:1:{i:0;s:18:\"Documentation Team\";}', '2019-12-03 11:00:00' ),
+			(NULL, 29, %d, '5', '2019-12-02 10:00:00' ),
+			(NULL, 30, %d, 'a:2:{i:0;s:9:\"Meta Team\";i:1;s:13:\"Training Team\";}', '2019-12-03 11:00:00' ),
 			(NULL, 29, %d, '7', '2019-12-02 10:00:00' ),
 			(NULL, 30, %d, 'a:1:{i:0;s:14:\"Polyglots Team\";}', '2019-12-03 11:00:00' ),
 			(NULL, 29, %d, '4', '2019-12-02 10:00:00' ),
@@ -118,7 +128,9 @@ function database_set_up( array $user_ids ) : void {
 		$user_ids[2],
 		$user_ids[2],
 		$user_ids[3],
-		$user_ids[3]
+		$user_ids[3],
+		$user_ids[4],
+		$user_ids[4]
 	) );
 }
 

--- a/plugins/wporg-5ftf/tests/test-contributor.php
+++ b/plugins/wporg-5ftf/tests/test-contributor.php
@@ -36,7 +36,7 @@ class Test_Contributor extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		TestHelpers\database_set_up( self::$users['jane']->ID, self::$users['ashish']->ID );
+		TestHelpers\database_set_up( array_values( wp_list_pluck( self::$users, 'ID' ) ) );
 		reset_phpmailer_instance();
 	}
 

--- a/plugins/wporg-5ftf/tests/test-contributor.php
+++ b/plugins/wporg-5ftf/tests/test-contributor.php
@@ -275,22 +275,32 @@ class Test_Contributor extends WP_UnitTestCase {
 		$contributors = array(
 			'active + due for email' => array(
 				'last_logged_in'             => strtotime( '1 week ago' ),
+				'user_registered'            => strtotime( '1 year ago' ),
 				'5ftf_last_inactivity_email' => 0,
 			),
 
 			'active + not due for email' => array(
 				'last_logged_in'             => strtotime( '1 week ago' ),
+				'user_registered'            => strtotime( '1 year ago' ),
 				'5ftf_last_inactivity_email' => strtotime( '1 month ago' ),
 			),
 
 			'inactive + due for email' => array(
 				'last_logged_in'             => strtotime( '4 months ago' ),
+				'user_registered'            => strtotime( '1 year ago' ),
 				'5ftf_last_inactivity_email' => strtotime( '4 months ago' ),
 			),
 
 			'inactive + not due for email' => array(
 				'last_logged_in'             => strtotime( '4 months ago' ),
+				'user_registered'            => strtotime( '1 year ago' ),
 				'5ftf_last_inactivity_email' => strtotime( '2 months ago' ),
+			),
+
+			'new user' => array(
+				'last_logged_in'             => 0,
+				'user_registered'            => strtotime( '1 week ago' ),
+				'5ftf_last_inactivity_email' => 0,
 			),
 		);
 

--- a/plugins/wporg-5ftf/tests/test-stats.php
+++ b/plugins/wporg-5ftf/tests/test-stats.php
@@ -1,0 +1,89 @@
+<?php
+
+use function WordPressDotOrg\FiveForTheFuture\Stats\{ get_snapshot_data };
+use WordPressDotOrg\FiveForTheFuture\{ Contributor };
+use WordPressDotOrg\FiveForTheFuture\Tests\Helpers as TestHelpers;
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @group stats
+ */
+class Test_Stats extends WP_UnitTestCase {
+	protected static $users;
+	protected static $pages;
+	protected static $pledges;
+
+	/**
+	 * Run once when class loads.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		$fixtures      = TestHelpers\database_setup_before_class( self::factory() );
+		self::$users   = $fixtures['users'];
+		self::$pages   = $fixtures['pages'];
+		self::$pledges = $fixtures['pledges'];
+	}
+
+	/**
+	 * Run before every test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		TestHelpers\database_set_up( array_values( wp_list_pluck( self::$users, 'ID' ) ) );
+	}
+
+	/**
+	 * Run once after all tests are finished.
+	 */
+	public static function tear_down_after_class() {
+		parent::tear_down_after_class();
+		TestHelpers\database_tear_down_after_class();
+	}
+
+	/**
+	 * @covers ::get_snapshot_data
+	 */
+	public function test_get_snapshot() : void {
+		// Setup 2 company-sponsored contributors.
+		$jane                = self::$users['jane'];
+		$ashish              = self::$users['ashish'];
+		$tenup               = self::$pledges['10up'];
+		$tenup_contributors  = Contributor\add_pledge_contributors( $tenup->ID, array( $jane->user_login, $ashish->user_login ) );
+		$tenup_jane_id       = $tenup_contributors[ $jane->user_login ];
+		$tenup_ashish_id     = $tenup_contributors[ $ashish->user_login ];
+
+		wp_update_post( array(
+			'ID'          => $tenup_jane_id,
+			'post_status' => 'publish',
+		) );
+		wp_update_post( array(
+			'ID'          => $tenup_ashish_id,
+			'post_status' => 'publish',
+		) );
+
+		$expected = array(
+			'company_sponsored_hours' => 75,
+			'self_sponsored_hours'    => 11,
+
+			'team_company_sponsored_contributors' => array(
+				'Core Team'          => 1,
+				'Documentation Team' => 1,
+			),
+
+			'team_self_sponsored_contributors' => array(
+				'Meta Team'      => 1,
+				'Polyglots Team' => 1,
+			),
+
+			'companies'                              => 2,
+			'company_sponsored_contributors'         => 2,
+			'self_sponsored_contributors'            => 2,
+			'self_sponsored_contributor_activity'    => 50.0,
+			'company_sponsored_contributor_activity' => 50.0,
+		);
+
+		$this->assertSame( $expected, get_snapshot_data() );
+	}
+}

--- a/plugins/wporg-5ftf/tests/test-stats.php
+++ b/plugins/wporg-5ftf/tests/test-stats.php
@@ -65,7 +65,7 @@ class Test_Stats extends WP_UnitTestCase {
 
 		$expected = array(
 			'company_sponsored_hours' => 75,
-			'self_sponsored_hours'    => 11,
+			'self_sponsored_hours'    => 16,
 
 			'team_company_sponsored_contributors' => array(
 				'Core Team'          => 1,
@@ -73,17 +73,20 @@ class Test_Stats extends WP_UnitTestCase {
 			),
 
 			'team_self_sponsored_contributors' => array(
-				'Meta Team'      => 1,
+				'Meta Team'      => 2,
 				'Polyglots Team' => 1,
+				'Training Team'  => 1,
 			),
 
 			'companies'                              => 2,
 			'company_sponsored_contributors'         => 2,
-			'self_sponsored_contributors'            => 2,
-			'self_sponsored_contributor_activity'    => 50.0,
+			'self_sponsored_contributors'            => 3,
+			'self_sponsored_contributor_activity'    => 33.33,
 			'company_sponsored_contributor_activity' => 50.0,
 		);
 
-		$this->assertSame( $expected, get_snapshot_data() );
+		$actual = get_snapshot_data();
+
+		$this->assertSame( $expected, $actual );
 	}
 }


### PR DESCRIPTION
WIP

It works locally, but the changes to `add_user_data_to_xprofile()` in f132f74 changed the hours/team count stats, because users who were previously included in the result are currently skipped. That's because they don't have any of the meta fields that they users query is trying to `group_concat()`

I'll finish fixing that when I get back from AFK.