### PR TITLE
Fix badge circle

### DIFF
--- a/themes/wporg-5ftf/css/components/_team-badges.scss
+++ b/themes/wporg-5ftf/css/components/_team-badges.scss
@@ -11,6 +11,7 @@
 	li {
 		display: flex;
 		align-items: center;
+		gap: 5px;
 		margin: 0 1em .5em 0;
 		width: 100%;
 	}
@@ -35,6 +36,8 @@
 
 .badge {
 	margin: 4px;
+	min-width: 32px;
+    min-height: 32px;
 	width: 32px;
 	height: 32px;
 	border: 2px solid white;

--- a/themes/wporg-5ftf/css/components/_team-badges.scss
+++ b/themes/wporg-5ftf/css/components/_team-badges.scss
@@ -37,7 +37,7 @@
 .badge {
 	margin: 4px;
 	min-width: 32px;
-    min-height: 32px;
+	min-height: 32px;
 	width: 32px;
 	height: 32px;
 	border: 2px solid white;


### PR DESCRIPTION
Reference: https://wordpress.org/five-for-the-future/pledge/benjamin-zekavica-projects/ 
I fixed the Circle CSS for displaying the badges and spacing on the single page. 

**Before:** 

![before](https://github.com/WordPress/five-for-the-future/assets/15845265/1988f557-698b-4982-9ae2-0dd29bdf67e7)


**After:**

![after](https://github.com/WordPress/five-for-the-future/assets/15845265/c8605cb6-5751-45a8-a238-b1733c81703e)

