### PR TITLE
Create report of potentially inactive pledged contributors

### DIFF
--- a/plugins/wporg-5ftf/includes/contributor.php
+++ b/plugins/wporg-5ftf/includes/contributor.php
@@ -7,9 +7,9 @@ use WP_Error, WP_Post, WP_User;
 
 defined( 'WPINC' ) || die();
 
-const SLUG    = 'contributor';
-const SLUG_PL = 'contributors';
-const CPT_ID  = FiveForTheFuture\PREFIX . '_' . SLUG;
+const SLUG                        = 'contributor';
+const SLUG_PL                     = 'contributors';
+const CPT_ID                      = FiveForTheFuture\PREFIX . '_' . SLUG;
 const INACTIVITY_THRESHOLD_MONTHS = 3;
 
 add_action( 'init',                                      __NAMESPACE__ . '\register_custom_post_type', 0 );
@@ -197,7 +197,7 @@ function add_pledge_contributors( $pledge_id, $contributors ) {
  * Some contributors are sponsored by multiple companies. They'll have a `5ftf_contributor` post for each company,
  * but only the post associated with the given pledge should be removed.
  */
-function remove_pledge_contributors( int $pledge_id ) : void {
+function remove_pledge_contributors( int $pledge_id ): void {
 	$contributors = get_pledge_contributors( $pledge_id, 'all' );
 
 	foreach ( $contributors as $status_group ) {
@@ -291,7 +291,7 @@ function get_pledge_contributors( $pledge_id, $status = 'publish', $contributor_
 		if ( empty( $posts ) ) {
 			$posts = $initial;
 		} else {
-			$posts = array_reduce( $posts, function( $carry, WP_Post $item ) {
+			$posts = array_reduce( $posts, function ( $carry, WP_Post $item ) {
 				$carry[ $item->post_status ][] = $item;
 
 				return $carry;
@@ -318,7 +318,7 @@ function get_pledge_contributors_data( $pledge_id ) {
 
 	foreach ( $contributors as $contributor_status => $group ) {
 		$contrib_data[ $contributor_status ] = array_map(
-			function( $contributor_post ) use ( $contributor_status, $pledge_id ) {
+			function ( $contributor_post ) use ( $contributor_status, $pledge_id ) {
 				$name        = $contributor_post->post_title;
 				$contributor = get_user_by( 'login', $name );
 
@@ -352,7 +352,7 @@ function get_pledge_contributors_data( $pledge_id ) {
  * @return WP_User[]
  */
 function get_contributor_user_objects( array $contributor_posts ) {
-	return array_map( function( WP_Post $post ) {
+	return array_map( function ( WP_Post $post ) {
 		return get_user_by( 'login', $post->post_title );
 	}, $contributor_posts );
 }
@@ -601,7 +601,7 @@ function parse_contributors( $contributors, $pledge_id = null ) {
  *
  * @codeCoverageIgnore
  */
-function notify_inactive_contributors() : void {
+function notify_inactive_contributors(): void {
 	$contributors = get_inactive_contributor_batch();
 	$contributors = prune_unnotifiable_xprofiles( $contributors );
 	$contributors = add_user_data_to_xprofile( $contributors );
@@ -624,7 +624,7 @@ function notify_inactive_contributors() : void {
 /**
  * Get the next group of inactive contributors.
  */
-function get_inactive_contributor_batch() : array {
+function get_inactive_contributor_batch(): array {
 	global $wpdb;
 
 	$batch_size = 500; // This can be large because most users will be pruned later on.
@@ -677,7 +677,7 @@ function get_inactive_contributor_batch() : array {
 /**
  * Prune xprofile rows for users who shouldn't be notified of their inactivity.
  */
-function prune_unnotifiable_xprofiles( array $xprofiles ) : array {
+function prune_unnotifiable_xprofiles( array $xprofiles ): array {
 	$notifiable_teams = array( 'Polyglots Team', 'Training Team' );
 
 	foreach ( $xprofiles as $index => $xprofile ) {
@@ -710,7 +710,7 @@ function prune_unnotifiable_xprofiles( array $xprofiles ) : array {
 /**
  * Merge user data with xprofile data.
  */
-function add_user_data_to_xprofile( array $xprofiles ) : array {
+function add_user_data_to_xprofile( array $xprofiles ): array {
 	global $wpdb;
 
 	if ( empty( $xprofiles ) ) {
@@ -747,12 +747,12 @@ function add_user_data_to_xprofile( array $xprofiles ) : array {
 
 	foreach ( $established_users as $user ) {
 		$full_user = array(
-			'user_id'        => absint( $user->ID ),
-			'user_login'     => $user->user_login,
-			'user_email'     => $user->user_email,
+			'user_id'         => absint( $user->ID ),
+			'user_login'      => $user->user_login,
+			'user_email'      => $user->user_email,
 			'user_registered' => intval( strtotime( $user->user_registered ) ),
-			'hours_per_week' => $xprofiles[ $user->ID ]->hours_per_week,
-			'user_nicename'  => $user->user_nicename,
+			'hours_per_week'  => $xprofiles[ $user->ID ]->hours_per_week,
+			'user_nicename'   => $user->user_nicename,
 		);
 
 		if ( ! empty( $user->meta_keys ) ) {
@@ -777,7 +777,7 @@ function add_user_data_to_xprofile( array $xprofiles ) : array {
 /**
  * Prune users who shouldn't be notified of their inactivity.
  */
-function prune_unnotifiable_users( array $contributors ) : array {
+function prune_unnotifiable_users( array $contributors ): array {
 	$inactivity_threshold = strtotime( INACTIVITY_THRESHOLD_MONTHS . ' months ago' );
 
 	foreach ( $contributors as $index => $contributor ) {
@@ -817,7 +817,7 @@ function prune_unnotifiable_users( array $contributors ) : array {
  *
  * @link https://github.com/WordPress/five-for-the-future/issues/210
  */
-function is_active( int $last_login ) : bool {
+function is_active( int $last_login ): bool {
 	$inactivity_threshold = strtotime( INACTIVITY_THRESHOLD_MONTHS . ' months ago' );
 
 	return $last_login > $inactivity_threshold;
@@ -826,7 +826,7 @@ function is_active( int $last_login ) : bool {
 /**
  * Notify an inactive contributor.
  */
-function notify_inactive_contributor( array $contributor ) : void {
+function notify_inactive_contributor( array $contributor ): void {
 	if ( ! Email\send_contributor_inactive_email( $contributor ) ) {
 		return;
 	}

--- a/plugins/wporg-5ftf/includes/xprofile.php
+++ b/plugins/wporg-5ftf/includes/xprofile.php
@@ -22,7 +22,7 @@ defined( 'WPINC' ) || die();
  * The "Sponsored" field is not retrieved because it's usually not needed, and including it would significantly
  * hurt performance.
  */
-function get_all_xprofile_contributor_hours_teams() : array {
+function get_all_xprofile_contributor_hours_teams(): array {
 	global $wpdb;
 
 	// This might need a `LIMIT` in the future as more users save values, but it's performant as of August 2022.
@@ -114,10 +114,10 @@ function prepare_xprofile_contribution_data( array $raw_data ) {
 	$field_keys_by_id = array_flip( FIELD_IDS );
 
 	foreach ( $raw_data as $datum ) {
-		$user_id     = $datum['user_id'];
+		$user_id                              = $datum['user_id'];
 		$prepared_data[ $user_id ]['user_id'] = $user_id;
-		$field_key   = $field_keys_by_id[ (int) $datum['field_id'] ];
-		$field_value = maybe_unserialize( $datum['value'] );
+		$field_key                            = $field_keys_by_id[ (int) $datum['field_id'] ];
+		$field_value                          = maybe_unserialize( $datum['value'] );
 
 		if ( ! isset( $prepared_data[ $user_id ]['sponsored'] ) ) {
 			$prepared_data[ $user_id ]['sponsored'] = false;
@@ -163,7 +163,7 @@ function get_aggregate_contributor_data_for_pledge( $pledge_id ) {
 		'teams'        => array(),
 	);
 
-	$aggregate_data = array_reduce( $data, function( $carry, $item ) {
+	$aggregate_data = array_reduce( $data, function ( $carry, $item ) {
 		switch ( $item['field_id'] ) {
 			case FIELD_IDS['hours_per_week']:
 				$carry['hours'] += absint( $item['value'] );
@@ -179,7 +179,7 @@ function get_aggregate_contributor_data_for_pledge( $pledge_id ) {
 	}, $initial );
 
 	$aggregate_data['teams'] = array_map(
-		function( $team ) {
+		function ( $team ) {
 			// Fix for renamed team.
 			if ( 'Theme Review Team' === $team ) {
 				$team = 'Themes Team';
@@ -235,7 +235,7 @@ function get_contributor_user_data( $user_id ) {
  * This deletes directly from the database and object cache -- rather than using something like
  * `BP_XProfile_Field::delete()` -- because w.org/5 runs on a different network than profiles.w.org.
  */
-function reset_contribution_data( $user_id ) : void {
+function reset_contribution_data( $user_id ): void {
 	global $wpdb;
 
 	$wpdb->query( $wpdb->prepare( '

--- a/plugins/wporg-5ftf/includes/xprofile.php
+++ b/plugins/wporg-5ftf/includes/xprofile.php
@@ -84,6 +84,10 @@ function get_all_xprofile_contributor_hours_teams() : array {
 function get_xprofile_contribution_data( array $user_ids ) {
 	global $wpdb;
 
+	if ( empty( $user_ids ) ) {
+		return array();
+	}
+
 	$sql = $wpdb->prepare( '
 		SELECT user_id, field_id, value
 		FROM bpmain_bp_xprofile_data
@@ -111,6 +115,7 @@ function prepare_xprofile_contribution_data( array $raw_data ) {
 
 	foreach ( $raw_data as $datum ) {
 		$user_id     = $datum['user_id'];
+		$prepared_data[ $user_id ]['user_id'] = $user_id;
 		$field_key   = $field_keys_by_id[ (int) $datum['field_id'] ];
 		$field_value = maybe_unserialize( $datum['value'] );
 

--- a/plugins/wporg-5ftf/tests/test-stats.php
+++ b/plugins/wporg-5ftf/tests/test-stats.php
@@ -78,6 +78,12 @@ class Test_Stats extends WP_UnitTestCase {
 				'Training Team'  => 1,
 			),
 
+			'inactive_contributor_ids'               => array(
+				0 => 9,
+				1 => 11,
+				2 => 13,
+			),
+
 			'companies'                              => 2,
 			'company_sponsored_contributors'         => 2,
 			'self_sponsored_contributors'            => 3,

--- a/plugins/wporg-5ftf/tests/test-stats.php
+++ b/plugins/wporg-5ftf/tests/test-stats.php
@@ -1,8 +1,8 @@
 <?php
 
-use function WordPressDotOrg\FiveForTheFuture\Stats\{ get_snapshot_data };
 use WordPressDotOrg\FiveForTheFuture\{ Contributor };
 use WordPressDotOrg\FiveForTheFuture\Tests\Helpers as TestHelpers;
+use function WordPressDotOrg\FiveForTheFuture\Stats\{ get_snapshot_data };
 
 defined( 'WPINC' ) || die();
 
@@ -45,14 +45,14 @@ class Test_Stats extends WP_UnitTestCase {
 	/**
 	 * @covers WordPressDotOrg\FiveForTheFuture\Stats\get_snapshot_data
 	 */
-	public function test_get_snapshot() : void {
+	public function test_get_snapshot(): void {
 		// Setup 2 company-sponsored contributors.
-		$jane                = self::$users['jane'];
-		$ashish              = self::$users['ashish'];
-		$tenup               = self::$pledges['10up'];
-		$tenup_contributors  = Contributor\add_pledge_contributors( $tenup->ID, array( $jane->user_login, $ashish->user_login ) );
-		$tenup_jane_id       = $tenup_contributors[ $jane->user_login ];
-		$tenup_ashish_id     = $tenup_contributors[ $ashish->user_login ];
+		$jane               = self::$users['jane'];
+		$ashish             = self::$users['ashish'];
+		$tenup              = self::$pledges['10up'];
+		$tenup_contributors = Contributor\add_pledge_contributors( $tenup->ID, array( $jane->user_login, $ashish->user_login ) );
+		$tenup_jane_id      = $tenup_contributors[ $jane->user_login ];
+		$tenup_ashish_id    = $tenup_contributors[ $ashish->user_login ];
 
 		wp_update_post( array(
 			'ID'          => $tenup_jane_id,
@@ -64,15 +64,15 @@ class Test_Stats extends WP_UnitTestCase {
 		) );
 
 		$expected = array(
-			'company_sponsored_hours' => 75,
-			'self_sponsored_hours'    => 16,
+			'company_sponsored_hours'                => 75,
+			'self_sponsored_hours'                   => 16,
 
-			'team_company_sponsored_contributors' => array(
+			'team_company_sponsored_contributors'    => array(
 				'Core Team'          => 1,
 				'Documentation Team' => 1,
 			),
 
-			'team_self_sponsored_contributors' => array(
+			'team_self_sponsored_contributors'       => array(
 				'Meta Team'      => 2,
 				'Polyglots Team' => 1,
 				'Training Team'  => 1,


### PR DESCRIPTION
This creates a basic report of contributors that have made a weekly pledge but appear to be inactive. That way someone can reach out to check if they need any help getting involved.

<img width="1411" alt="Screenshot 2023-11-03 at 5 39 00 PM" src="https://github.com/WordPress/five-for-the-future/assets/484068/d9e21e87-a0ea-4561-9538-37e0a843cc80">
