### PR TITLE
Increase z-index for pledge background

### DIFF
--- a/themes/wporg-5ftf-2024/src/pledge-edit-button/style.scss
+++ b/themes/wporg-5ftf-2024/src/pledge-edit-button/style.scss
@@ -9,7 +9,7 @@
 
 .pledge-dialog {
 	position: absolute;
-	z-index: 100;
+	z-index: 252;
 	width: 25rem;
 	margin-top: var(--wp--preset--spacing--10);
 	padding: var(--wp--preset--spacing--20);
@@ -47,7 +47,7 @@
 
 .pledge-dialog__background {
 	position: fixed;
-	z-index: 99;
+	z-index: 251;
 	top: 0;
 	left: 0;
 	bottom: 0;

--- a/themes/wporg-5ftf-2024/src/pledge-edit-button/style.scss
+++ b/themes/wporg-5ftf-2024/src/pledge-edit-button/style.scss
@@ -47,7 +47,7 @@
 
 .pledge-dialog__background {
 	position: fixed;
-	z-index: 251; /* header + 1. */
+	z-index: 99;
 	top: 0;
 	left: 0;
 	bottom: 0;

--- a/themes/wporg-5ftf-2024/src/pledge-edit-button/style.scss
+++ b/themes/wporg-5ftf-2024/src/pledge-edit-button/style.scss
@@ -47,7 +47,7 @@
 
 .pledge-dialog__background {
 	position: fixed;
-	z-index: 251;
+	z-index: 251; /* header + 1. */
 	top: 0;
 	left: 0;
 	bottom: 0;


### PR DESCRIPTION
- reduces the z-index from 251 to 99, to avoid the form not being editable.

this is a temp fix for #319 - the [old theme](https://github.com/WordPress/five-for-the-future/blob/production/themes/wporg-5ftf/css/components/_pledge-dialog.scss#L47) seems to have it set at this value so need a double-check on this in case there are unintended consequences of reducing it.

props martinkrcho