### PR TITLE
Pledges: Keep the pledge search away from Jetpack Search

### DIFF
--- a/plugins/wporg-5ftf/includes/pledge.php
+++ b/plugins/wporg-5ftf/includes/pledge.php
@@ -23,6 +23,7 @@ const DEACTIVE_STATUS = FiveForTheFuture\PREFIX . '-deactivated';
 add_action( 'init',          __NAMESPACE__ . '\register', 0 );
 add_action( 'admin_menu',    __NAMESPACE__ . '\admin_menu' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\filter_query' );
+add_filter( 'jetpack_search_should_handle_query', __NAMESPACE__ . '\bypass_jetpack_search', 10, 2 );
 // List table columns.
 add_filter( 'manage_edit-' . CPT_ID . '_columns',        __NAMESPACE__ . '\add_list_table_columns' );
 add_action( 'manage_' . CPT_ID . '_posts_custom_column', __NAMESPACE__ . '\populate_list_table_columns', 10, 2 );
@@ -459,6 +460,27 @@ function filter_query( $query ) {
 				break;
 		}
 	}
+}
+
+/**
+ * Keep pledge searches away from Jetpack Search, so they run against the database.
+ *
+ * Jetpack Search strips every `exclude_from_search` post type before querying Elasticsearch.
+ * The pledge post type is registered that way, so Jetpack is left with nothing to search and
+ * calls `WP_Query::set_404()`, turning every pledge search into a 404. Pledges are not in the
+ * Elasticsearch index anyway.
+ *
+ * @param bool     $should_handle Whether Jetpack Search should handle the query.
+ * @param WP_Query $query         The query being filtered.
+ *
+ * @return bool
+ */
+function bypass_jetpack_search( $should_handle, $query ) {
+	if ( $query->is_main_query() && $query->is_search() ) {
+		return false;
+	}
+
+	return $should_handle;
 }
 
 /**

--- a/plugins/wporg-5ftf/tests/test-pledge.php
+++ b/plugins/wporg-5ftf/tests/test-pledge.php
@@ -1,0 +1,49 @@
+<?php
+
+use function WordPressDotOrg\FiveForTheFuture\Pledge\{ bypass_jetpack_search };
+
+defined( 'WPINC' ) || die();
+
+/**
+ * @group pledge
+ */
+class Test_Pledge extends WP_UnitTestCase {
+	/**
+	 * Jetpack Search must not handle the pledge search.
+	 *
+	 * It drops every `exclude_from_search` post type before querying Elasticsearch, which
+	 * leaves it with nothing to search and makes it call `WP_Query::set_404()`. That turned
+	 * every pledge search into a 404, even though the database query found the pledges.
+	 *
+	 * @covers ::bypass_jetpack_search
+	 */
+	public function test_bypass_jetpack_search_declines_main_search_query() {
+		$this->go_to( '/?s=example' );
+
+		global $wp_query;
+
+		$this->assertTrue( $wp_query->is_main_query(), 'Expected the global query to be the main query.' );
+		$this->assertTrue( $wp_query->is_search(), 'Expected a search query.' );
+		$this->assertFalse( bypass_jetpack_search( true, $wp_query ) );
+	}
+
+	/**
+	 * Queries other than the main search should be left alone, so that Jetpack Search keeps
+	 * whatever behaviour it would otherwise have.
+	 *
+	 * @covers ::bypass_jetpack_search
+	 */
+	public function test_bypass_jetpack_search_ignores_other_queries() {
+		$this->go_to( '/?s=example' );
+
+		$secondary = new WP_Query( array( 's' => 'example' ) );
+		$this->assertFalse( $secondary->is_main_query(), 'Expected a secondary query.' );
+		$this->assertTrue( bypass_jetpack_search( true, $secondary ), 'Secondary search queries should pass through.' );
+
+		$this->go_to( '/' );
+
+		global $wp_query;
+		$this->assertFalse( $wp_query->is_search(), 'Expected a non-search query.' );
+		$this->assertTrue( bypass_jetpack_search( true, $wp_query ), 'Non-search queries should pass through.' );
+	}
+}


### PR DESCRIPTION
Fixes #391.

The pledge post type is registered with `exclude_from_search`. Jetpack Search strips every such post type before querying Elasticsearch, so it was left with nothing to search and called `WP_Query::set_404()` — flagging the request as a 404 before the database query ran. The pledges were found; the 404 template rendered anyway.

This opts the main search query out of Jetpack Search so it runs against the database. Pledges are not in the Elasticsearch index anyway.

### Testing

Verified on a sandbox: `hosting` returns 5 results, `10up` and `Automattic` 1 each, and a term with no matches now renders the "no results" page instead of a 404. The pledge archive, sorting, single pledge pages and front page are unchanged.

Note: I was unable to run the PHPUnit suite locally — `composer install` currently fails on `wporg/wporg-mu-plugins` (stale commit hash, unrelated to this change), so CI will be the first run of the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Acymh4bG9S4bbihubF87ho
